### PR TITLE
fixed a bug with 'exit' command and standby

### DIFF
--- a/addons/armaos/functions/fnc_os_exit.sqf
+++ b/addons/armaos/functions/fnc_os_exit.sqf
@@ -23,3 +23,5 @@ _terminal set ["AE3_terminalPrompt", "LOGIN>"];
 _terminal set ["AE3_terminalBuffer", []];
 _terminal set ["AE3_terminalCursorLine", 0];
 _terminal set ["AE3_terminalCursorPosition", 0];
+
+[_computer] call AE3_armaos_fnc_terminal_addHeader;

--- a/addons/armaos/functions/fnc_terminal_init.sqf
+++ b/addons/armaos/functions/fnc_terminal_init.sqf
@@ -109,8 +109,9 @@ if (_terminalBuffer isEqualTo []) then
 	{
 		[_computer] call AE3_armaos_fnc_terminal_updatePromptPointer;
 	};
-	[_computer] call AE3_armaos_fnc_terminal_setPrompt;
 };
+
+[_computer] call AE3_armaos_fnc_terminal_setPrompt;
 
 [_computer, _consoleOutput] call AE3_armaos_fnc_terminal_updateOutput;
 


### PR DESCRIPTION
@Wasserstoff removed this line of code in a previous fix. This breaks the `exit` command:

```sqf
[_computer] call AE3_armaos_fnc_terminal_addHeader;
```

Additionally there was a need to modify terminal init function for that case.