### PR TITLE
fixed exception message on missing algorythm

### DIFF
--- a/addons/armaos/functions/fnc_os_crack.sqf
+++ b/addons/armaos/functions/fnc_os_crack.sqf
@@ -50,7 +50,7 @@ _message = [_message, _allowedAlphabet + " "] call BIS_fnc_filterString;
 
 if (_mode isEqualTo "bruteforce") then
 {
-    if (!(_algorythm in _allowedAlgorythms)) exitWith { [ _computer, format [localize "STR_AE3_ArmaOS_Exception_CommandHasMissingMessage", _commandName] ] call AE3_armaos_fnc_shell_stdout; };
+    if (!(_algorythm in _allowedAlgorythms)) exitWith { [ _computer, format [localize "STR_AE3_ArmaOS_Exception_CommandHasMissingAlgorythm", _commandName] ] call AE3_armaos_fnc_shell_stdout; };
 
     if (_algorythm == "caesar") then
     {


### PR DESCRIPTION
Merging this pull request will show the correct feedback message/exception text if someone uses a unknown algorythm or missed to name the algorythm completely when using the `crack` command. Prior to that PR the feedback message indicated that the 'message' aka the encrypted text, thats needs to be cracked, is missing, which is wrong.