### PR TITLE
Fixed exception handling for createFile and createDir function calls

### DIFF
--- a/addons/armaos/functions/fnc_module_addUser.sqf
+++ b/addons/armaos/functions/fnc_module_addUser.sqf
@@ -26,7 +26,7 @@ if(!isServer) exitWith {};
 			try
 			{
 				[[], _filesystem, "/home/" + _user, 'root', _user] call AE3_filesystem_fnc_createDir;
-			} catch {};
+			} catch { diag_log format ["AE3 exception: %1", _exception]; };
 		};
 
 		_x setVariable ["AE3_filesystem", _filesystem];

--- a/addons/armaos/functions/fnc_module_addUser.sqf
+++ b/addons/armaos/functions/fnc_module_addUser.sqf
@@ -26,7 +26,19 @@ if(!isServer) exitWith {};
 			try
 			{
 				[[], _filesystem, "/home/" + _user, 'root', _user] call AE3_filesystem_fnc_createDir;
-			} catch { diag_log format ["AE3 exception: %1", _exception]; };
+			} 
+			catch
+			{
+				private _normalizedException = _exception regexReplace ["'(.+)'", "'%1'"];
+				if (_normalizedException isEqualTo (localize "STR_AE3_Filesystem_Exception_AlreadyExists")) then
+				{
+					diag_log format ["AE3 exception: %1", _exception];
+				}
+				else
+				{
+					throw _exception;
+				};
+			};
 		};
 
 		_x setVariable ["AE3_filesystem", _filesystem];

--- a/addons/filesystem/functions/fnc_initFilesystem.sqf
+++ b/addons/filesystem/functions/fnc_initFilesystem.sqf
@@ -35,26 +35,34 @@ private _filesystemObjects = ("inheritsFrom _x == (configFile >> 'AE3_Filesystem
 
 	if (_type isEqualTo "File") then
 	{
-		[
-			_ptr, 
-			_filesystem, 
-			_path, 
-			(getText (_x >> "content")), 
-			"root", 
-			_owner,
-			_permissions 
-		] call AE3_filesystem_fnc_createFile;
+		// throws exception if file already exists
+		try 
+		{
+			[
+				_ptr, 
+				_filesystem, 
+				_path, 
+				(getText (_x >> "content")), 
+				"root", 
+				_owner,
+				_permissions 
+			] call AE3_filesystem_fnc_createFile;
+		} catch { diag_log format ["AE3 exception: %1", _exception]; };
 	}
 	else
 	{
-		[
-			_ptr,
-			_filesystem,
-			_path,
-			"root",
-			_owner, 
-			_permissions
-		] call AE3_filesystem_fnc_createDir;
+		// throws exception if directory already exists
+		try 
+		{
+			[
+				_ptr,
+				_filesystem,
+				_path,
+				"root",
+				_owner, 
+				_permissions
+			] call AE3_filesystem_fnc_createDir;
+		} catch { diag_log format ["AE3 exception: %1", _exception]; };
 	};
 } forEach _filesystemObjects;
 

--- a/addons/filesystem/functions/fnc_initFilesystem.sqf
+++ b/addons/filesystem/functions/fnc_initFilesystem.sqf
@@ -47,7 +47,19 @@ private _filesystemObjects = ("inheritsFrom _x == (configFile >> 'AE3_Filesystem
 				_owner,
 				_permissions 
 			] call AE3_filesystem_fnc_createFile;
-		} catch { diag_log format ["AE3 exception: %1", _exception]; };
+		} 
+		catch
+		{
+			private _normalizedException = _exception regexReplace ["'(.+)'", "'%1'"];
+			if (_normalizedException isEqualTo (localize "STR_AE3_Filesystem_Exception_AlreadyExists")) then
+			{
+				diag_log format ["AE3 exception: %1", _exception];
+			}
+			else
+			{
+				throw _exception;
+			};
+		};
 	}
 	else
 	{
@@ -62,7 +74,19 @@ private _filesystemObjects = ("inheritsFrom _x == (configFile >> 'AE3_Filesystem
 				_owner, 
 				_permissions
 			] call AE3_filesystem_fnc_createDir;
-		} catch { diag_log format ["AE3 exception: %1", _exception]; };
+		} 
+		catch
+		{
+			private _normalizedException = _exception regexReplace ["'(.+)'", "'%1'"];
+			if (_normalizedException isEqualTo (localize "STR_AE3_Filesystem_Exception_AlreadyExists")) then
+			{
+				diag_log format ["AE3 exception: %1", _exception];
+			}
+			else
+			{
+				throw _exception;
+			};
+		};
 	};
 } forEach _filesystemObjects;
 

--- a/addons/filesystem/functions/fnc_moduleAddDir.sqf
+++ b/addons/filesystem/functions/fnc_moduleAddDir.sqf
@@ -40,14 +40,19 @@ if(_path isEqualTo "") exitWith {};
 
 	{
 		_filesystem = _x getVariable "AE3_filesystem";
-		[
-			[],
-			_filesystem,
-			_path,
-			"root",
-			_owner,
-			_permissions
-		] call AE3_filesystem_fnc_createDir;
+
+		// throws exception if directory already exists
+		try 
+		{
+			[
+				[],
+				_filesystem,
+				_path,
+				"root",
+				_owner,
+				_permissions
+			] call AE3_filesystem_fnc_createDir;
+		} catch { diag_log format ["AE3 exception: %1", _exception]; };
 
 		_x setVariable ["AE3_filesystem", _filesystem];
 	} forEach _syncedObjects;

--- a/addons/filesystem/functions/fnc_moduleAddDir.sqf
+++ b/addons/filesystem/functions/fnc_moduleAddDir.sqf
@@ -52,7 +52,19 @@ if(_path isEqualTo "") exitWith {};
 				_owner,
 				_permissions
 			] call AE3_filesystem_fnc_createDir;
-		} catch { diag_log format ["AE3 exception: %1", _exception]; };
+		} 
+		catch
+		{
+			private _normalizedException = _exception regexReplace ["'(.+)'", "'%1'"];
+			if (_normalizedException isEqualTo (localize "STR_AE3_Filesystem_Exception_AlreadyExists")) then
+			{
+				diag_log format ["AE3 exception: %1", _exception];
+			}
+			else
+			{
+				throw _exception;
+			};
+		};
 
 		_x setVariable ["AE3_filesystem", _filesystem];
 	} forEach _syncedObjects;

--- a/addons/filesystem/functions/fnc_moduleAddFile.sqf
+++ b/addons/filesystem/functions/fnc_moduleAddFile.sqf
@@ -60,7 +60,19 @@ if(_isFunction) then
 				_owner,
 				_permissions
 			] call AE3_filesystem_fnc_createFile;
-		} catch { diag_log format ["AE3 exception: %1", _exception]; };
+		} 
+		catch
+		{
+			private _normalizedException = _exception regexReplace ["'(.+)'", "'%1'"];
+			if (_normalizedException isEqualTo (localize "STR_AE3_Filesystem_Exception_AlreadyExists")) then
+			{
+				diag_log format ["AE3 exception: %1", _exception];
+			}
+			else
+			{
+				throw _exception;
+			};
+		};
 
 		_x setVariable ["AE3_filesystem", _filesystem];
 	} forEach _syncedObjects;

--- a/addons/filesystem/functions/fnc_moduleAddFile.sqf
+++ b/addons/filesystem/functions/fnc_moduleAddFile.sqf
@@ -47,15 +47,21 @@ if(_isFunction) then
 
 	{
 		_filesystem = _x getVariable "AE3_filesystem";
-		[
-			[],
-			_filesystem,
-			_path,
-			_content,
-			"root",
-			_owner,
-			_permissions
-		] call AE3_filesystem_fnc_createFile;
+
+		// throws exception if file already exists
+		try 
+		{
+			[
+				[],
+				_filesystem,
+				_path,
+				_content,
+				"root",
+				_owner,
+				_permissions
+			] call AE3_filesystem_fnc_createFile;
+		} catch { diag_log format ["AE3 exception: %1", _exception]; };
+
 		_x setVariable ["AE3_filesystem", _filesystem];
 	} forEach _syncedObjects;
 };


### PR DESCRIPTION
By merging this Pull Request every call of createDir or createFile function is embedded in a try/catch-block. Both functions thow errors if the filesystem object already exists. This happens for example if you snyc identical modules multiple times to the same computer. The exceptions are now logged in the *.rpt file. 