### PR TITLE
split texture variants into separate classes

### DIFF
--- a/addons/armaos/CfgVehicles.hpp
+++ b/addons/armaos/CfgVehicles.hpp
@@ -1,90 +1,11 @@
 class CfgVehicles 
 {
+	/* ================================================================================ */
 	
-	// LAPTOP
-	class Land_Laptop_03_sand_F;
-	class Land_Laptop_03_sand_F_AE3: Land_Laptop_03_sand_F
+	// LAPTOP BLACK
+	class Land_Laptop_03_black_F;
+	class Land_Laptop_03_black_F_AE3: Land_Laptop_03_black_F
 	{
-		class TextureSources
-		{
-			class Black
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_ArmaOS_Config_TextureBlack";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Equipment\data\Laptop_03_black_CO.paa"};
-			};
-			class Olive
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_ArmaOS_Config_TextureOlive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Equipment\data\Laptop_03_olive_CO.paa"};
-			};
-			class Sand
-			{
-				displayName = "$STR_AE3_ArmaOS_Config_TextureSand";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Equipment\data\Laptop_03_sand_CO.paa"};
-			};
-		};
-
-		simulation = "tankX";
-		preciseGetInOut = 0;
-		cargoPreciseGetInOut[] = {};
-		cargoProxyIndexes[] = {};
-		alphaTracks = 0;
-		class MFD {};
-		class Sounds {};
-		canFloat = 0;
-		leftDustEffect = "";
-		rightDustEffect = "";
-		leftWaterEffect = "";
-		rightWaterEffect = "";
-		tracksSpeed = 0;
-		class CargoLight
-		{
-			ambient[] = {0.6,0,0.15,1};
-			brightness = 0.007;
-			color[] = {0,0,0,0};
-		};
-		fireDustEffect = "";
-		turnCoef = 0;
-		class SquadTitles
-		{
-			color[] = {0,0,0,0};
-			name = "clan_sign";
-		};
-		class Exhausts {};
-		class RenderTargets {};
-		driverDoor = "";
-		cargoDoors[] = {};
-		selectionLeftOffset = "";
-		selectionRightOffset = "";
-		selectionBrakeLights = "";
-		memoryPointMissile = "";
-		memoryPointMissileDir = "";
-		textureTrackWheel = "";
-		memoryPointTrack1L = "";
-		memoryPointTrack2L = "";
-		gearBox[] = {};
-		memoryPointDriverOptics = "";
-		memoryPointsGetInDriver = "";
-		memoryPointsGetInDriverDir = "";
-		memoryPointsGetInCoDriver = "";
-		memoryPointsGetInCoDriverDir = "";
-		memoryPointsGetInCargo = "";
-		memoryPointsGetInCargoDir = "";
-		driverLeftHandAnimName = "";
-		driverRightHandAnimName = "";
-		driverLeftLegAnimName = "";
-		driverRightLegAnimName = "";
-		soundGear[] = {"",0.316228,1};
-		memoryPointsLeftWaterEffect = "";
-		memoryPointsRightWaterEffect = "";
-		memoryPointCargoLight = "";
-
         // Carrying
         ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
         ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
@@ -190,6 +111,230 @@ class CfgVehicles
 		};
 	};
 
+	/* ================================================================================ */
+
+	// LAPTOP OLIVE
+	class Land_Laptop_03_olive_F;
+	class Land_Laptop_03_olive_F_AE3: Land_Laptop_03_olive_F
+	{
+        // Carrying
+        ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+        ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+        ace_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+        ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+        ace_cargo_size = 1;  // Cargo space the object takes
+
+		// Event Handlers
+		class EventHandlers
+		{
+			//init = "params ['_entity']; call compile preprocessFileLineNumbers '\z\ae3\addons\main\init\initLaptop.sqf';";
+		};
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_ArmaOS_Config_LaptopDisplayName";
+
+			closeState = 0;
+
+			init = "_this call AE3_interaction_fnc_initLaptop;";
+
+			openAction = "_this call AE3_interaction_fnc_laptop_open;";
+			openActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+			closeAction = "_this call AE3_interaction_fnc_laptop_close;";
+			closeActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+		};
+
+		class AE3_Device
+		{
+			displayName = "$STR_AE3_ArmaOS_Config_LaptopDisplayName";
+			defaultPowerLevel = 0;
+
+			init = "_this call AE3_filesystem_fnc_initFilesystem; _this call AE3_armaos_fnc_link_init; _this call AE3_network_fnc_initNetworkDevice;";
+
+			turnOnAction = "_this call AE3_network_fnc_dhcp_onTurnOn; _this call AE3_armaos_fnc_computer_turnOn;";
+			turnOnActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+			turnOffAction = "_this call AE3_armaos_fnc_computer_turnOff;";
+			turnOffActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+			standByAction = "_this call AE3_armaos_fnc_computer_standby;";
+			standByActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.01/3600; // 10 Watts
+				standbyConsumption = 0.0001/3600; // 0.1 Watts
+			};
+		};
+
+		class AE3_InternalDevice
+		{
+			displayName = "$STR_AE3_ArmaOS_Config_BatteryDisplayName";
+			defaultPowerLevel = 1;
+
+			turnOnAction = "_this + [true] call AE3_power_fnc_turnOnBatteryAction";
+			turnOffAction = "";
+
+			class AE3_PowerInterface
+			{
+				internal = 1;
+			};
+
+			class AE3_Battery
+			{
+				capacity = 0.1; // 100 Watts/hour max. capacity
+				recharging = 0.05/3600; // 50 Watts power consumption while recharging
+				level = 0.1; // 100 Watts/hour capacity at the beginning
+				internal = 1;
+			};
+		};
+
+		
+        class ACE_Actions 
+		{
+			class ACE_MainActions
+			{
+				displayName = "$STR_ACE_Interaction_MainAction";
+				condition = "true";
+				distance = 2;
+				class AE3_Laptop_Group
+				{
+					displayName = "$STR_AE3_ArmaOS_Config_ArmaOSDisplayName";
+					condition = "true";
+					class AE3_UseComputer
+					{
+						displayName = "$STR_AE3_ArmaOS_Config_UseDisplayName";
+						condition = "(alive _target) && (_target getVariable 'AE3_power_powerState' == 1) && (isNull (_target getVariable ['AE3_computer_mutex', objNull]))";
+						statement = "params ['_target', '_player', '_params']; _target setVariable ['AE3_computer_mutex', _player, true]; _handle = [_target] spawn AE3_armaos_fnc_terminal_init;";
+						//icon = "\z\dance.paa";
+						exceptions[] = {};
+						//insertChildren
+						//modifierFunction
+						//runOnHover
+						//distance
+						//position
+						//selection
+						priority = -1;
+						showDisabled = 0;
+					};
+				};
+			};
+		};
+	};
+
+	/* ================================================================================ */
+	
+	// LAPTOP SAND
+	class Land_Laptop_03_sand_F;
+	class Land_Laptop_03_sand_F_AE3: Land_Laptop_03_sand_F
+	{
+        // Carrying
+        ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+        ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+        ace_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+        ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+        ace_cargo_size = 1;  // Cargo space the object takes
+
+		// Event Handlers
+		class EventHandlers
+		{
+			//init = "params ['_entity']; call compile preprocessFileLineNumbers '\z\ae3\addons\main\init\initLaptop.sqf';";
+		};
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_ArmaOS_Config_LaptopDisplayName";
+
+			closeState = 0;
+
+			init = "_this call AE3_interaction_fnc_initLaptop;";
+
+			openAction = "_this call AE3_interaction_fnc_laptop_open;";
+			openActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+			closeAction = "_this call AE3_interaction_fnc_laptop_close;";
+			closeActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+		};
+
+		class AE3_Device
+		{
+			displayName = "$STR_AE3_ArmaOS_Config_LaptopDisplayName";
+			defaultPowerLevel = 0;
+
+			init = "_this call AE3_filesystem_fnc_initFilesystem; _this call AE3_armaos_fnc_link_init; _this call AE3_network_fnc_initNetworkDevice;";
+
+			turnOnAction = "_this call AE3_network_fnc_dhcp_onTurnOn; _this call AE3_armaos_fnc_computer_turnOn;";
+			turnOnActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+			turnOffAction = "_this call AE3_armaos_fnc_computer_turnOff;";
+			turnOffActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+			standByAction = "_this call AE3_armaos_fnc_computer_standby;";
+			standByActionCondition = "isNull (_this getVariable ['AE3_computer_mutex', objNull])";
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.01/3600; // 10 Watts
+				standbyConsumption = 0.0001/3600; // 0.1 Watts
+			};
+		};
+
+		class AE3_InternalDevice
+		{
+			displayName = "$STR_AE3_ArmaOS_Config_BatteryDisplayName";
+			defaultPowerLevel = 1;
+
+			turnOnAction = "_this + [true] call AE3_power_fnc_turnOnBatteryAction";
+			turnOffAction = "";
+
+			class AE3_PowerInterface
+			{
+				internal = 1;
+			};
+
+			class AE3_Battery
+			{
+				capacity = 0.1; // 100 Watts/hour max. capacity
+				recharging = 0.05/3600; // 50 Watts power consumption while recharging
+				level = 0.1; // 100 Watts/hour capacity at the beginning
+				internal = 1;
+			};
+		};
+
+		
+        class ACE_Actions 
+		{
+			class ACE_MainActions
+			{
+				displayName = "$STR_ACE_Interaction_MainAction";
+				condition = "true";
+				distance = 2;
+				class AE3_Laptop_Group
+				{
+					displayName = "$STR_AE3_ArmaOS_Config_ArmaOSDisplayName";
+					condition = "true";
+					class AE3_UseComputer
+					{
+						displayName = "$STR_AE3_ArmaOS_Config_UseDisplayName";
+						condition = "(alive _target) && (_target getVariable 'AE3_power_powerState' == 1) && (isNull (_target getVariable ['AE3_computer_mutex', objNull]))";
+						statement = "params ['_target', '_player', '_params']; _target setVariable ['AE3_computer_mutex', _player, true]; _handle = [_target] spawn AE3_armaos_fnc_terminal_init;";
+						//icon = "\z\dance.paa";
+						exceptions[] = {};
+						//insertChildren
+						//modifierFunction
+						//runOnHover
+						//distance
+						//position
+						//selection
+						priority = -1;
+						showDisabled = 0;
+					};
+				};
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
 	// MODULE USERLIST
 	class Logic;
 	class Module_F: Logic
@@ -276,4 +421,6 @@ class CfgVehicles
 			};
 		};
 	};
+
+	/* ================================================================================ */
 };

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -3,7 +3,6 @@ class CfgVehicles
 	/* ================================================================================ */
 
 	class Land_PortableLight_single_F;
-
 	class Land_PortableLight_single_F_AE3: Land_PortableLight_single_F
 	{
 		// Carrying
@@ -43,7 +42,6 @@ class CfgVehicles
 	/* ================================================================================ */
 	
  	class Land_PortableLight_double_F;
-
 	class Land_PortableLight_double_F_AE3: Land_PortableLight_double_F
 	{
         // Carrying
@@ -82,97 +80,10 @@ class CfgVehicles
 
 	/* ================================================================================ */
 
- 	class Land_PortableLight_02_single_sand_F;
-
-	class Land_PortableLight_02_single_sand_F_AE3: Land_PortableLight_02_single_sand_F
+	// RUGGED LAMP SINGLE YELLOW
+ 	class Land_PortableLight_02_single_yellow_F;
+	class Land_PortableLight_02_single_yellow_F_AE3: Land_PortableLight_02_single_yellow_F
 	{
-		class TextureSources
-		{
-			class Black
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureBlack";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Single_Black_CO.paa"};
-			};
-			class Olive
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureOlive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Single_Olive_CO.paa"};
-			};
-			class Yellow
-			{
-				displayName = "$STR_AE3_Interaction_Config_TextureYellow";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Single_Yellow_CO.paa"};
-			};
-			class Sand
-			{
-				displayName = "$STR_AE3_Interaction_Config_TextureSand";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Single_Sand_CO.paa"};
-			};
-		};
-
-		simulation = "tankX";
-		preciseGetInOut = 0;
-		cargoPreciseGetInOut[] = {};
-		cargoProxyIndexes[] = {};
-		alphaTracks = 0;
-		class MFD {};
-		class Sounds {};
-		canFloat = 0;
-		leftDustEffect = "";
-		rightDustEffect = "";
-		leftWaterEffect = "";
-		rightWaterEffect = "";
-		tracksSpeed = 0;
-		class CargoLight
-		{
-			ambient[] = {0.6,0,0.15,1};
-			brightness = 0.007;
-			color[] = {0,0,0,0};
-		};
-		fireDustEffect = "";
-		turnCoef = 0;
-		class SquadTitles
-		{
-			color[] = {0,0,0,0};
-			name = "clan_sign";
-		};
-		class Exhausts {};
-		class RenderTargets {};
-		driverDoor = "";
-		cargoDoors[] = {};
-		selectionLeftOffset = "";
-		selectionRightOffset = "";
-		selectionBrakeLights = "";
-		memoryPointMissile = "";
-		memoryPointMissileDir = "";
-		textureTrackWheel = "";
-		memoryPointTrack1L = "";
-		memoryPointTrack2L = "";
-		gearBox[] = {};
-		memoryPointDriverOptics = "";
-		memoryPointsGetInDriver = "";
-		memoryPointsGetInDriverDir = "";
-		memoryPointsGetInCoDriver = "";
-		memoryPointsGetInCoDriverDir = "";
-		memoryPointsGetInCargo = "";
-		memoryPointsGetInCargoDir = "";
-		driverLeftHandAnimName = "";
-		driverRightHandAnimName = "";
-		driverLeftLegAnimName = "";
-		driverRightLegAnimName = "";
-		soundGear[] = {"",0.316228,1};
-		memoryPointsLeftWaterEffect = "";
-		memoryPointsRightWaterEffect = "";
-		memoryPointCargoLight = "";
-
 		// Carrying
 		ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
 		ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
@@ -263,97 +174,292 @@ class CfgVehicles
 
 	/* ================================================================================ */
 
-	class Land_PortableLight_02_double_sand_F;
-
-	class Land_PortableLight_02_double_sand_F_AE3: Land_PortableLight_02_double_sand_F
+	// RUGGED LAMP SINGLE OLIVE
+ 	class Land_PortableLight_02_single_olive_F;
+	class Land_PortableLight_02_single_olive_F_AE3: Land_PortableLight_02_single_olive_F
 	{
-		class TextureSources
+		// Carrying
+		ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+		ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 1;  // Cargo space the object takes
+
+		class AE3_Equipment
 		{
-			class Black
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+
+			class AE3_Animations
 			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureBlack";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Black_CO.paa"};
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp1";
+					selection = "light_1_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp1";
+						animation = "Light_1_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp1";
+						animation = "Light_1_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp1";
+						animation = "Light_1_yaw_source";
+						minValue = -180;
+						maxValue = 180;
+						scrollMultiplier = 10;
+					};
+				};
 			};
-			class Olive
+
+			class AE3_aceWorkaround
 			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureOlive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Olive_CO.paa"};
-			};
-			class Yellow
-			{
-				displayName = "$STR_AE3_Interaction_Config_TextureYellow";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Yellow_CO.paa"};
-			};
-			class Sand
-			{
-				displayName = "$STR_AE3_Interaction_Config_TextureSand";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Sand_CO.paa"};
+				class AE3_aceCarrying
+				{
+					// Carrying
+					ae3_dragging_canCarry = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
 			};
 		};
 
-		simulation = "tankX";
-		preciseGetInOut = 0;
-		cargoPreciseGetInOut[] = {};
-		cargoProxyIndexes[] = {};
-		alphaTracks = 0;
-		class MFD {};
-		class Sounds {};
-		canFloat = 0;
-		leftDustEffect = "";
-		rightDustEffect = "";
-		leftWaterEffect = "";
-		rightWaterEffect = "";
-		tracksSpeed = 0;
-		class CargoLight
+		class AE3_Device
 		{
-			ambient[] = {0.6,0,0.15,1};
-			brightness = 0.007;
-			color[] = {0,0,0,0};
-		};
-		fireDustEffect = "";
-		turnCoef = 0;
-		class SquadTitles
-		{
-			color[] = {0,0,0,0};
-			name = "clan_sign";
-		};
-		class Exhausts {};
-		class RenderTargets {};
-		driverDoor = "";
-		cargoDoors[] = {};
-		selectionLeftOffset = "";
-		selectionRightOffset = "";
-		selectionBrakeLights = "";
-		memoryPointMissile = "";
-		memoryPointMissileDir = "";
-		textureTrackWheel = "";
-		memoryPointTrack1L = "";
-		memoryPointTrack2L = "";
-		gearBox[] = {};
-		memoryPointDriverOptics = "";
-		memoryPointsGetInDriver = "";
-		memoryPointsGetInDriverDir = "";
-		memoryPointsGetInCoDriver = "";
-		memoryPointsGetInCoDriverDir = "";
-		memoryPointsGetInCargo = "";
-		memoryPointsGetInCargoDir = "";
-		driverLeftHandAnimName = "";
-		driverRightHandAnimName = "";
-		driverLeftLegAnimName = "";
-		driverRightLegAnimName = "";
-		soundGear[] = {"",0.316228,1};
-		memoryPointsLeftWaterEffect = "";
-		memoryPointsRightWaterEffect = "";
-		memoryPointCargoLight = "";
+			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
 
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_interaction_fnc_lamp_turnOn";
+			turnOffAction = "_this call AE3_interaction_fnc_lamp_turnOff";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.025/3600; // 25 Watts (1x 25 Watts)
+			};
+		};
+
+		class EventHandlers
+		{
+			init = "_this call AE3_interaction_fnc_compileEquipment; _this call AE3_power_fnc_compileDevice;";
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED LAMP SINGLE BLACK
+ 	class Land_PortableLight_02_single_black_F;
+	class Land_PortableLight_02_single_black_F_AE3: Land_PortableLight_02_single_black_F
+	{
+		// Carrying
+		ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+		ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 1;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+
+			class AE3_Animations
+			{
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp1";
+					selection = "light_1_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp1";
+						animation = "Light_1_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp1";
+						animation = "Light_1_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp1";
+						animation = "Light_1_yaw_source";
+						minValue = -180;
+						maxValue = 180;
+						scrollMultiplier = 10;
+					};
+				};
+			};
+
+			class AE3_aceWorkaround
+			{
+				class AE3_aceCarrying
+				{
+					// Carrying
+					ae3_dragging_canCarry = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
+			};
+		};
+
+		class AE3_Device
+		{
+			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
+
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_interaction_fnc_lamp_turnOn";
+			turnOffAction = "_this call AE3_interaction_fnc_lamp_turnOff";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.025/3600; // 25 Watts (1x 25 Watts)
+			};
+		};
+
+		class EventHandlers
+		{
+			init = "_this call AE3_interaction_fnc_compileEquipment; _this call AE3_power_fnc_compileDevice;";
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED LAMP SINGLE SAND
+ 	class Land_PortableLight_02_single_sand_F;
+	class Land_PortableLight_02_single_sand_F_AE3: Land_PortableLight_02_single_sand_F
+	{
+		// Carrying
+		ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+		ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 1;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+
+			class AE3_Animations
+			{
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp1";
+					selection = "light_1_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp1";
+						animation = "Light_1_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp1";
+						animation = "Light_1_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp1";
+						animation = "Light_1_yaw_source";
+						minValue = -180;
+						maxValue = 180;
+						scrollMultiplier = 10;
+					};
+				};
+			};
+
+			class AE3_aceWorkaround
+			{
+				class AE3_aceCarrying
+				{
+					// Carrying
+					ae3_dragging_canCarry = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
+			};
+		};
+
+		class AE3_Device
+		{
+			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
+
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_interaction_fnc_lamp_turnOn";
+			turnOffAction = "_this call AE3_interaction_fnc_lamp_turnOff";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.025/3600; // 25 Watts (1x 25 Watts)
+			};
+		};
+
+		class EventHandlers
+		{
+			init = "_this call AE3_interaction_fnc_compileEquipment; _this call AE3_power_fnc_compileDevice;";
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED LAMP DOUBLE YELLOW
+	class Land_PortableLight_02_double_yellow_F;
+	class Land_PortableLight_02_double_yellow_F_AE3: Land_PortableLight_02_double_yellow_F
+	{
 		// Dragging
 		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
 		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
@@ -477,97 +583,391 @@ class CfgVehicles
 
 	/* ================================================================================ */
 
-	class Land_PortableLight_02_quad_sand_F;
-
-	class Land_PortableLight_02_quad_sand_F_AE3: Land_PortableLight_02_quad_sand_F
+	// RUGGED LAMP DOUBLE OLIVE
+	class Land_PortableLight_02_double_olive_F;
+	class Land_PortableLight_02_double_olive_F_AE3: Land_PortableLight_02_double_olive_F
 	{
-		class TextureSources
+		// Dragging
+		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 2;  // Cargo space the object takes
+
+		class AE3_Equipment
 		{
-			class Black
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+
+			class AE3_Animations
 			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureBlack";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Black_CO.paa"};
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp1";
+					selection = "light_1_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp1";
+						animation = "Light_1_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp1";
+						animation = "Light_1_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp1";
+						animation = "Light_1_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_1
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp2";
+					selection = "light_2_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp2";
+						animation = "Light_2_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp2";
+						animation = "Light_2_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp2";
+						animation = "Light_2_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
 			};
-			class Olive
+
+			class AE3_aceWorkaround
 			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureOlive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Olive_CO.paa"};
-			};
-			class Yellow
-			{
-				displayName = "$STR_AE3_Interaction_Config_TextureYellow";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Yellow_CO.paa"};
-			};
-			class Sand
-			{
-				displayName = "$STR_AE3_Interaction_Config_TextureSand";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\Portable_light_02_Sand_CO.paa"};
+				class AE3_aceDragging
+				{
+					// Dragging
+					ae3_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
 			};
 		};
 
-		simulation = "tankX";
-		preciseGetInOut = 0;
-		cargoPreciseGetInOut[] = {};
-		cargoProxyIndexes[] = {};
-		alphaTracks = 0;
-		class MFD {};
-		class Sounds {};
-		canFloat = 0;
-		leftDustEffect = "";
-		rightDustEffect = "";
-		leftWaterEffect = "";
-		rightWaterEffect = "";
-		tracksSpeed = 0;
-		class CargoLight
+		class AE3_Device
 		{
-			ambient[] = {0.6,0,0.15,1};
-			brightness = 0.007;
-			color[] = {0,0,0,0};
-		};
-		fireDustEffect = "";
-		turnCoef = 0;
-		class SquadTitles
-		{
-			color[] = {0,0,0,0};
-			name = "clan_sign";
-		};
-		class Exhausts {};
-		class RenderTargets {};
-		driverDoor = "";
-		cargoDoors[] = {};
-		selectionLeftOffset = "";
-		selectionRightOffset = "";
-		selectionBrakeLights = "";
-		memoryPointMissile = "";
-		memoryPointMissileDir = "";
-		textureTrackWheel = "";
-		memoryPointTrack1L = "";
-		memoryPointTrack2L = "";
-		gearBox[] = {};
-		memoryPointDriverOptics = "";
-		memoryPointsGetInDriver = "";
-		memoryPointsGetInDriverDir = "";
-		memoryPointsGetInCoDriver = "";
-		memoryPointsGetInCoDriverDir = "";
-		memoryPointsGetInCargo = "";
-		memoryPointsGetInCargoDir = "";
-		driverLeftHandAnimName = "";
-		driverRightHandAnimName = "";
-		driverLeftLegAnimName = "";
-		driverRightLegAnimName = "";
-		soundGear[] = {"",0.316228,1};
-		memoryPointsLeftWaterEffect = "";
-		memoryPointsRightWaterEffect = "";
-		memoryPointCargoLight = "";
+			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
 
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_interaction_fnc_lamp_turnOn";
+			turnOffAction = "_this call AE3_interaction_fnc_lamp_turnOff";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.05/3600; // 50 Watts (2x 25 Watts)
+			};
+		};
+
+		class EventHandlers
+		{
+			init = "_this call AE3_interaction_fnc_compileEquipment; _this call AE3_power_fnc_compileDevice;";
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED LAMP DOUBLE BLACK
+	class Land_PortableLight_02_double_black_F;
+	class Land_PortableLight_02_double_black_F_AE3: Land_PortableLight_02_double_black_F
+	{
+		// Dragging
+		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 2;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+
+			class AE3_Animations
+			{
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp1";
+					selection = "light_1_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp1";
+						animation = "Light_1_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp1";
+						animation = "Light_1_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp1";
+						animation = "Light_1_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_1
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp2";
+					selection = "light_2_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp2";
+						animation = "Light_2_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp2";
+						animation = "Light_2_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp2";
+						animation = "Light_2_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+			};
+
+			class AE3_aceWorkaround
+			{
+				class AE3_aceDragging
+				{
+					// Dragging
+					ae3_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
+			};
+		};
+
+		class AE3_Device
+		{
+			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
+
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_interaction_fnc_lamp_turnOn";
+			turnOffAction = "_this call AE3_interaction_fnc_lamp_turnOff";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.05/3600; // 50 Watts (2x 25 Watts)
+			};
+		};
+
+		class EventHandlers
+		{
+			init = "_this call AE3_interaction_fnc_compileEquipment; _this call AE3_power_fnc_compileDevice;";
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED LAMP DOUBLE SAND
+	class Land_PortableLight_02_double_sand_F;
+	class Land_PortableLight_02_double_sand_F_AE3: Land_PortableLight_02_double_sand_F
+	{
+		// Dragging
+		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 2;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+
+			class AE3_Animations
+			{
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp1";
+					selection = "light_1_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp1";
+						animation = "Light_1_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp1";
+						animation = "Light_1_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp1";
+						animation = "Light_1_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_1
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp2";
+					selection = "light_2_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp2";
+						animation = "Light_2_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp2";
+						animation = "Light_2_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp2";
+						animation = "Light_2_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+			};
+
+			class AE3_aceWorkaround
+			{
+				class AE3_aceDragging
+				{
+					// Dragging
+					ae3_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
+			};
+		};
+
+		class AE3_Device
+		{
+			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
+
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_interaction_fnc_lamp_turnOn";
+			turnOffAction = "_this call AE3_interaction_fnc_lamp_turnOff";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.05/3600; // 50 Watts (2x 25 Watts)
+			};
+		};
+
+		class EventHandlers
+		{
+			init = "_this call AE3_interaction_fnc_compileEquipment; _this call AE3_power_fnc_compileDevice;";
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED LAMP QUAD YELLOW
+	class Land_PortableLight_02_quad_yellow_F;
+	class Land_PortableLight_02_quad_yellow_F_AE3: Land_PortableLight_02_quad_yellow_F
+	{
 		// Dragging
 		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
 		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
@@ -757,90 +1157,589 @@ class CfgVehicles
 
 	/* ================================================================================ */
 
-	// Desk
-	class Land_PortableDesk_01_sand_F;
-	class Land_PortableDesk_01_sand_F_AE3: Land_PortableDesk_01_sand_F
+	// RUGGED LAMP QUAD OLIVE
+	class Land_PortableLight_02_quad_olive_F;
+	class Land_PortableLight_02_quad_olive_F_AE3: Land_PortableLight_02_quad_olive_F
 	{
-		class TextureSources
+		// Dragging
+		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 2;  // Cargo space the object takes
+
+		class AE3_Equipment
 		{
-			class Black
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			
+			class AE3_Animations
 			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureBlack";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\PortableDesk_01_black_CO.paa"};
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp1";
+					selection = "light_1_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp1";
+						animation = "Light_1_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp1";
+						animation = "Light_1_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp1";
+						animation = "Light_1_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_1
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp2";
+					selection = "light_2_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp2";
+						animation = "Light_2_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp2";
+						animation = "Light_2_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp2";
+						animation = "Light_2_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_2
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp3";
+					selection = "light_3_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp3";
+						animation = "Light_3_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp3";
+						animation = "Light_3_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp3";
+						animation = "Light_3_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_3
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp4";
+					selection = "light_4_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp4";
+						animation = "Light_4_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp4";
+						animation = "Light_4_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp4";
+						animation = "Light_4_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
 			};
-			class Olive
+
+			class AE3_aceWorkaround
 			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureOlive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\PortableDesk_01_olive_CO.paa"};
-			};
-			class Sand
-			{
-				displayName = "$STR_AE3_Interaction_Config_TextureSand";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\PortableDesk_01_sand_CO.paa"};
+				class AE3_aceDragging
+				{
+					// Dragging
+					ae3_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
 			};
 		};
 
-		simulation = "tankX";
-		preciseGetInOut = 0;
-		cargoPreciseGetInOut[] = {};
-		cargoProxyIndexes[] = {};
-		alphaTracks = 0;
-		class MFD {};
-		class Sounds {};
-		canFloat = 0;
-		leftDustEffect = "";
-		rightDustEffect = "";
-		leftWaterEffect = "";
-		rightWaterEffect = "";
-		tracksSpeed = 0;
-		class CargoLight
+		class AE3_Device
 		{
-			ambient[] = {0.6,0,0.15,1};
-			brightness = 0.007;
-			color[] = {0,0,0,0};
-		};
-		fireDustEffect = "";
-		turnCoef = 0;
-		class SquadTitles
-		{
-			color[] = {0,0,0,0};
-			name = "clan_sign";
-		};
-		class Exhausts {};
-		class RenderTargets {};
-		driverDoor = "";
-		cargoDoors[] = {};
-		selectionLeftOffset = "";
-		selectionRightOffset = "";
-		selectionBrakeLights = "";
-		memoryPointMissile = "";
-		memoryPointMissileDir = "";
-		textureTrackWheel = "";
-		memoryPointTrack1L = "";
-		memoryPointTrack2L = "";
-		gearBox[] = {};
-		memoryPointDriverOptics = "";
-		memoryPointsGetInDriver = "";
-		memoryPointsGetInDriverDir = "";
-		memoryPointsGetInCoDriver = "";
-		memoryPointsGetInCoDriverDir = "";
-		memoryPointsGetInCargo = "";
-		memoryPointsGetInCargoDir = "";
-		driverLeftHandAnimName = "";
-		driverRightHandAnimName = "";
-		driverLeftLegAnimName = "";
-		driverRightLegAnimName = "";
-		soundGear[] = {"",0.316228,1};
-		memoryPointsLeftWaterEffect = "";
-		memoryPointsRightWaterEffect = "";
-		memoryPointCargoLight = "";
+			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
 
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_interaction_fnc_lamp_turnOn";
+			turnOffAction = "_this call AE3_interaction_fnc_lamp_turnOff";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.1/3600; // 100 Watts (4x 25 Watts)
+			};
+		};
+
+		class EventHandlers
+		{
+			init = "_this call AE3_interaction_fnc_compileEquipment; _this call AE3_power_fnc_compileDevice;";
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED LAMP QUAD BLACK
+	class Land_PortableLight_02_quad_black_F;
+	class Land_PortableLight_02_quad_black_F_AE3: Land_PortableLight_02_quad_black_F
+	{
+		// Dragging
+		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 2;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			
+			class AE3_Animations
+			{
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp1";
+					selection = "light_1_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp1";
+						animation = "Light_1_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp1";
+						animation = "Light_1_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp1";
+						animation = "Light_1_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_1
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp2";
+					selection = "light_2_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp2";
+						animation = "Light_2_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp2";
+						animation = "Light_2_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp2";
+						animation = "Light_2_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_2
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp3";
+					selection = "light_3_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp3";
+						animation = "Light_3_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp3";
+						animation = "Light_3_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp3";
+						animation = "Light_3_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_3
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp4";
+					selection = "light_4_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp4";
+						animation = "Light_4_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp4";
+						animation = "Light_4_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp4";
+						animation = "Light_4_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+			};
+
+			class AE3_aceWorkaround
+			{
+				class AE3_aceDragging
+				{
+					// Dragging
+					ae3_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
+			};
+		};
+
+		class AE3_Device
+		{
+			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
+
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_interaction_fnc_lamp_turnOn";
+			turnOffAction = "_this call AE3_interaction_fnc_lamp_turnOff";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.1/3600; // 100 Watts (4x 25 Watts)
+			};
+		};
+
+		class EventHandlers
+		{
+			init = "_this call AE3_interaction_fnc_compileEquipment; _this call AE3_power_fnc_compileDevice;";
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED LAMP QUAD SAND
+	class Land_PortableLight_02_quad_sand_F;
+	class Land_PortableLight_02_quad_sand_F_AE3: Land_PortableLight_02_quad_sand_F
+	{
+		// Dragging
+		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 2;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			
+			class AE3_Animations
+			{
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp1";
+					selection = "light_1_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp1";
+						animation = "Light_1_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp1";
+						animation = "Light_1_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp1";
+						animation = "Light_1_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_1
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp2";
+					selection = "light_2_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp2";
+						animation = "Light_2_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp2";
+						animation = "Light_2_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp2";
+						animation = "Light_2_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_2
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp3";
+					selection = "light_3_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp3";
+						animation = "Light_3_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp3";
+						animation = "Light_3_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp3";
+						animation = "Light_3_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+
+				class AE3_Animation_Point_3
+				{
+					description = "$STR_AE3_Interaction_Config_Lamp4";
+					selection = "light_4_pitch";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Interaction_Config_ExtendLamp4";
+						animation = "Light_4_extend_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+
+					class AE3_Animation_Modified_Ctrl
+					{
+						description = "$STR_AE3_Interaction_Config_PitchLamp4";
+						animation = "Light_4_pitch_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+
+					class AE3_Animation_Modified_Alt
+					{
+						description = "$STR_AE3_Interaction_Config_YawLamp4";
+						animation = "Light_4_yaw_source";
+						minValue = -90;
+						maxValue = 90;
+						scrollMultiplier = 10;
+					};
+				};
+			};
+
+			class AE3_aceWorkaround
+			{
+				class AE3_aceDragging
+				{
+					// Dragging
+					ae3_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
+			};
+		};
+
+		class AE3_Device
+		{
+			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
+
+			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_interaction_fnc_lamp_turnOn";
+			turnOffAction = "_this call AE3_interaction_fnc_lamp_turnOff";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.1/3600; // 100 Watts (4x 25 Watts)
+			};
+		};
+
+		class EventHandlers
+		{
+			init = "_this call AE3_interaction_fnc_compileEquipment; _this call AE3_power_fnc_compileDevice;";
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED DESK OLIVE
+	class Land_PortableDesk_01_olive_F;
+	class Land_PortableDesk_01_olive_F_AE3: Land_PortableDesk_01_olive_F
+	{
 		// Dragging
 		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
 		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
@@ -955,90 +1854,290 @@ class CfgVehicles
 
 	/* ================================================================================ */
 
-	// CHAIR
+	// RUGGED DESK BLACK
+	class Land_PortableDesk_01_black_F;
+	class Land_PortableDesk_01_black_F_AE3: Land_PortableDesk_01_black_F
+	{
+		// Dragging
+		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_dragDirection = 90;  // Model direction while dragging (same as setDir after attachTo)
+		
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 4;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Interaction_Config_DeskDisplayName";
+
+			closeState = 0;
+
+			init = "_this call AE3_interaction_fnc_initDesk;";
+
+			openAction = "_this call AE3_interaction_fnc_desk_open;";
+			closeAction = "_this call AE3_interaction_fnc_desk_close;";
+
+			class AE3_Animations
+			{
+				/*
+				class AE3_Animation_Point_0
+				{
+					description = "drawer 1";
+					selection = "drawer_1";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 1";
+						animation = "Drawer_1_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_1
+				{
+					description = "drawer 2";
+					selection = "drawer_2";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 2";
+						animation = "Drawer_2_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_2
+				{
+					description = "drawer 3";
+					selection = "drawer_3";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 3";
+						animation = "Drawer_3_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_3
+				{
+					description = "drawer 4";
+					selection = "drawer_4";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 4";
+						animation = "Drawer_4_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_4
+				{
+					description = "drawer 5";
+					selection = "drawer_5";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 5";
+						animation = "Drawer_5_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_5
+				{
+					description = "drawer 6";
+					selection = "drawer_6";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 6";
+						animation = "Drawer_6_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				*/
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED DESK SAND
+	class Land_PortableDesk_01_sand_F;
+	class Land_PortableDesk_01_sand_F_AE3: Land_PortableDesk_01_sand_F
+	{
+		// Dragging
+		ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+		ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_dragDirection = 90;  // Model direction while dragging (same as setDir after attachTo)
+		
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 4;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Interaction_Config_DeskDisplayName";
+
+			closeState = 0;
+
+			init = "_this call AE3_interaction_fnc_initDesk;";
+
+			openAction = "_this call AE3_interaction_fnc_desk_open;";
+			closeAction = "_this call AE3_interaction_fnc_desk_close;";
+
+			class AE3_Animations
+			{
+				/*
+				class AE3_Animation_Point_0
+				{
+					description = "drawer 1";
+					selection = "drawer_1";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 1";
+						animation = "Drawer_1_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_1
+				{
+					description = "drawer 2";
+					selection = "drawer_2";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 2";
+						animation = "Drawer_2_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_2
+				{
+					description = "drawer 3";
+					selection = "drawer_3";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 3";
+						animation = "Drawer_3_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_3
+				{
+					description = "drawer 4";
+					selection = "drawer_4";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 4";
+						animation = "Drawer_4_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_4
+				{
+					description = "drawer 5";
+					selection = "drawer_5";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 5";
+						animation = "Drawer_5_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				class AE3_Animation_Point_5
+				{
+					description = "drawer 6";
+					selection = "drawer_6";
+
+					class AE3_Animation_Main
+					{
+						description = "open/close drawer 6";
+						animation = "Drawer_6_move_source";
+						minValue = 0;
+						maxValue = 1;
+						scrollMultiplier = 0.1;
+					};
+				};
+				*/
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED CHAIR OLIVE
+	class Land_DeskChair_01_olive_F;
+	class Land_DeskChair_01_olive_F_AE3: Land_DeskChair_01_olive_F
+	{
+		//Sitting
+		acex_sitting_canSit = 1;  // Enable sitting
+		acex_sitting_interactPosition[] = {0, 0, 0.3}; 
+		acex_sitting_sitDirection = 180;  // Direction relative to object
+		acex_sitting_sitPosition[] = {0, -0.18, -0.45};  // Position relative to object (may behave weird with certain objects)
+	
+		// Carrying
+		ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+		ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_carryDirection = 180;  // Model direction while dragging (same as setDir after attachTo)
+		
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 1;  // Cargo space the object takes
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED CHAIR BLACK
+	class Land_DeskChair_01_black_F;
+	class Land_DeskChair_01_black_F_AE3: Land_DeskChair_01_black_F
+	{
+		//Sitting
+		acex_sitting_canSit = 1;  // Enable sitting
+		acex_sitting_interactPosition[] = {0, 0, 0.3}; 
+		acex_sitting_sitDirection = 180;  // Direction relative to object
+		acex_sitting_sitPosition[] = {0, -0.18, -0.45};  // Position relative to object (may behave weird with certain objects)
+	
+		// Carrying
+		ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+		ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_carryDirection = 180;  // Model direction while dragging (same as setDir after attachTo)
+		
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 1;  // Cargo space the object takes
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED CHAIR SAND
 	class Land_DeskChair_01_sand_F;
 	class Land_DeskChair_01_sand_F_AE3: Land_DeskChair_01_sand_F
 	{
-		class TextureSources
-		{
-			class Black
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureBlack";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\RuggedChair_01_black_CO.paa"};
-			};
-			class Olive
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Interaction_Config_TextureOlive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\RuggedChair_01_olive_CO.paa"};
-			};
-			class Sand
-			{
-				displayName = "$STR_AE3_Interaction_Config_TextureSand";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Camps\data\RuggedChair_01_sand_CO.paa"};
-			};
-		};
-
-		simulation = "tankX";
-		preciseGetInOut = 0;
-		cargoPreciseGetInOut[] = {};
-		cargoProxyIndexes[] = {};
-		alphaTracks = 0;
-		class MFD {};
-		class Sounds {};
-		canFloat = 0;
-		leftDustEffect = "";
-		rightDustEffect = "";
-		leftWaterEffect = "";
-		rightWaterEffect = "";
-		tracksSpeed = 0;
-		class CargoLight
-		{
-			ambient[] = {0.6,0,0.15,1};
-			brightness = 0.007;
-			color[] = {0,0,0,0};
-		};
-		fireDustEffect = "";
-		turnCoef = 0;
-		class SquadTitles
-		{
-			color[] = {0,0,0,0};
-			name = "clan_sign";
-		};
-		class Exhausts {};
-		class RenderTargets {};
-		driverDoor = "";
-		cargoDoors[] = {};
-		selectionLeftOffset = "";
-		selectionRightOffset = "";
-		selectionBrakeLights = "";
-		memoryPointMissile = "";
-		memoryPointMissileDir = "";
-		textureTrackWheel = "";
-		memoryPointTrack1L = "";
-		memoryPointTrack2L = "";
-		gearBox[] = {};
-		memoryPointDriverOptics = "";
-		memoryPointsGetInDriver = "";
-		memoryPointsGetInDriverDir = "";
-		memoryPointsGetInCoDriver = "";
-		memoryPointsGetInCoDriverDir = "";
-		memoryPointsGetInCargo = "";
-		memoryPointsGetInCargoDir = "";
-		driverLeftHandAnimName = "";
-		driverRightHandAnimName = "";
-		driverLeftLegAnimName = "";
-		driverRightLegAnimName = "";
-		soundGear[] = {"",0.316228,1};
-		memoryPointsLeftWaterEffect = "";
-		memoryPointsRightWaterEffect = "";
-		memoryPointCargoLight = "";
-
 		//Sitting
 		acex_sitting_canSit = 1;  // Enable sitting
 		acex_sitting_interactPosition[] = {0, 0, 0.3}; 

--- a/addons/network/CfgVehicles.hpp
+++ b/addons/network/CfgVehicles.hpp
@@ -1,6 +1,84 @@
 class CfgVehicles 
 {
-	// ROUTER
+	/* ================================================================================ */
+
+	// RUGGED ROUTER OLIVE
+	class Land_Router_01_olive_F;
+	class Land_Router_01_olive_F_AE3: Land_Router_01_olive_F
+	{
+        // Carrying
+        ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+        ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+        ace_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+        ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+        ace_cargo_size = 1;  // Cargo space the object takes
+
+
+		class AE3_Device
+		{
+			displayName = "$STR_AE3_Network_Config_RouterDisplayName";
+			init = "_this call AE3_network_fnc_initRouter;";
+
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_network_fnc_dhcp_onTurnOn; true";
+			turnOffAction = "true";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.01/3600; // consumes 10 Watts
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED ROUTER BLACK
+	class Land_Router_01_black_F;
+	class Land_Router_01_black_F_AE3: Land_Router_01_black_F
+	{
+        // Carrying
+        ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+        ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+        ace_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+        ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+        ace_cargo_size = 1;  // Cargo space the object takes
+
+
+		class AE3_Device
+		{
+			displayName = "$STR_AE3_Network_Config_RouterDisplayName";
+			init = "_this call AE3_network_fnc_initRouter;";
+
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_network_fnc_dhcp_onTurnOn; true";
+			turnOffAction = "true";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Consumer
+			{
+				powerConsumption = 0.01/3600; // consumes 10 Watts
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED ROUTER SAND
 	class Land_Router_01_sand_F;
 	class Land_Router_01_sand_F_AE3: Land_Router_01_sand_F
 	{
@@ -34,7 +112,7 @@ class CfgVehicles
 				powerConsumption = 0.01/3600; // consumes 10 Watts
 			};
 		};
-
 	};
 
+	/* ================================================================================ */
 };

--- a/addons/power/CfgVehicles.hpp
+++ b/addons/power/CfgVehicles.hpp
@@ -154,91 +154,10 @@ class CfgVehicles
 
 	/* ================================================================================ */
 
-	// Batteries
-	class Land_BatteryPack_01_open_sand_F;
-
-	class Land_BatteryPack_01_open_sand_F_AE3 : Land_BatteryPack_01_open_sand_F
+	// RUGGED BATTERY PACK OLIVE
+	class Land_BatteryPack_01_open_olive_F;
+	class Land_BatteryPack_01_open_olive_F_AE3 : Land_BatteryPack_01_open_olive_F
 	{
-		class TextureSources
-		{
-			class Black
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Power_Config_TextureBlack";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Equipment\data\BatteryPack_01_Black_CO.paa"};
-			};
-			class Olive
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Power_Config_TextureOlive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Equipment\data\BatteryPack_01_Olive_CO.paa"};
-			};
-			class Sand
-			{
-				displayName = "$STR_AE3_Power_Config_TextureSand";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Equipment\data\BatteryPack_01_Sand_CO.paa"};
-			};
-		};
-
-		simulation = "tankX";
-		preciseGetInOut = 0;
-		cargoPreciseGetInOut[] = {};
-		cargoProxyIndexes[] = {};
-		alphaTracks = 0;
-		class MFD {};
-		class Sounds {};
-		canFloat = 0;
-		leftDustEffect = "";
-		rightDustEffect = "";
-		leftWaterEffect = "";
-		rightWaterEffect = "";
-		tracksSpeed = 0;
-		class CargoLight
-		{
-			ambient[] = {0.6,0,0.15,1};
-			brightness = 0.007;
-			color[] = {0,0,0,0};
-		};
-		fireDustEffect = "";
-		turnCoef = 0;
-		class SquadTitles
-		{
-			color[] = {0,0,0,0};
-			name = "clan_sign";
-		};
-		class Exhausts {};
-		class RenderTargets {};
-		driverDoor = "";
-		cargoDoors[] = {};
-		selectionLeftOffset = "";
-		selectionRightOffset = "";
-		selectionBrakeLights = "";
-		memoryPointMissile = "";
-		memoryPointMissileDir = "";
-		textureTrackWheel = "";
-		memoryPointTrack1L = "";
-		memoryPointTrack2L = "";
-		gearBox[] = {};
-		memoryPointDriverOptics = "";
-		memoryPointsGetInDriver = "";
-		memoryPointsGetInDriverDir = "";
-		memoryPointsGetInCoDriver = "";
-		memoryPointsGetInCoDriverDir = "";
-		memoryPointsGetInCargo = "";
-		memoryPointsGetInCargoDir = "";
-		driverLeftHandAnimName = "";
-		driverRightHandAnimName = "";
-		driverLeftLegAnimName = "";
-		driverRightLegAnimName = "";
-		soundGear[] = {"",0.316228,1};
-		memoryPointsLeftWaterEffect = "";
-		memoryPointsRightWaterEffect = "";
-		memoryPointCargoLight = "";
-
 		// Carrying
 		ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
 		ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
@@ -273,91 +192,86 @@ class CfgVehicles
 
 	/* ================================================================================ */
 
-	// Solar Panels
-	class Land_SolarPanel_04_sand_F;
-
-	class Land_SolarPanel_04_sand_F_AE3 : Land_SolarPanel_04_sand_F
+	// RUGGED BATTERY PACK BLACK
+	class Land_BatteryPack_01_open_black_F;
+	class Land_BatteryPack_01_open_black_F_AE3 : Land_BatteryPack_01_open_black_F
 	{
-		class TextureSources
-		{
-			class Black
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Power_Config_TextureBlack";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Equipment\data\SolarPanel_04_F_Black_CO.paa"};
-			};
-			class Olive
-			{
-				author = "Bohemia Interactive";
-				displayName = "$STR_AE3_Power_Config_TextureOlive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Equipment\data\SolarPanel_04_F_Olive_CO.paa"};
-			};
-			class Sand
-			{
-				displayName = "$STR_AE3_Power_Config_TextureSand";
-				author = "Bohemia Interactive";
-				factions[] = {};
-				textures[] = {"a3\Props_F_Enoch\Military\Equipment\data\SolarPanel_04_F_Sand_CO.paa"};
-			};
-		};
+		// Carrying
+		ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+		ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
 
-		simulation = "tankX";
-		preciseGetInOut = 0;
-		cargoPreciseGetInOut[] = {};
-		cargoProxyIndexes[] = {};
-		alphaTracks = 0;
-		class MFD {};
-		class Sounds {};
-		canFloat = 0;
-		leftDustEffect = "";
-		rightDustEffect = "";
-		leftWaterEffect = "";
-		rightWaterEffect = "";
-		tracksSpeed = 0;
-		class CargoLight
-		{
-			ambient[] = {0.6,0,0.15,1};
-			brightness = 0.007;
-			color[] = {0,0,0,0};
-		};
-		fireDustEffect = "";
-		turnCoef = 0;
-		class SquadTitles
-		{
-			color[] = {0,0,0,0};
-			name = "clan_sign";
-		};
-		class Exhausts {};
-		class RenderTargets {};
-		driverDoor = "";
-		cargoDoors[] = {};
-		selectionLeftOffset = "";
-		selectionRightOffset = "";
-		selectionBrakeLights = "";
-		memoryPointMissile = "";
-		memoryPointMissileDir = "";
-		textureTrackWheel = "";
-		memoryPointTrack1L = "";
-		memoryPointTrack2L = "";
-		gearBox[] = {};
-		memoryPointDriverOptics = "";
-		memoryPointsGetInDriver = "";
-		memoryPointsGetInDriverDir = "";
-		memoryPointsGetInCoDriver = "";
-		memoryPointsGetInCoDriverDir = "";
-		memoryPointsGetInCargo = "";
-		memoryPointsGetInCargoDir = "";
-		driverLeftHandAnimName = "";
-		driverRightHandAnimName = "";
-		driverLeftLegAnimName = "";
-		driverRightLegAnimName = "";
-		soundGear[] = {"",0.316228,1};
-		memoryPointsLeftWaterEffect = "";
-		memoryPointsRightWaterEffect = "";
-		memoryPointCargoLight = "";
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 1;  // Cargo space the object takes
 
+		class AE3_Device
+		{
+			displayName = "$STR_AE3_Power_Config_BatteryDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_power_fnc_turnOnBatteryAction";
+			turnOffAction = "_this call AE3_power_fnc_turnOffBatteryAction";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Battery
+			{
+				capacity = 0.6; // 600 Watts/hour max. capacity
+				recharging = 0.3/3600; // 300 Watts power consumption while recharging
+				level = 0.6; // 600 Watts/hour capacity at the beginning
+				internal = 0;
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED BATTERY PACK SAND
+	class Land_BatteryPack_01_open_sand_F;
+	class Land_BatteryPack_01_open_sand_F_AE3 : Land_BatteryPack_01_open_sand_F
+	{
+		// Carrying
+		ace_dragging_canCarry = 1;  // Can be carried (0-no, 1-yes)
+		ace_dragging_carryPosition[] = {0, 1, 1};  // Offset of the model from the body while dragging (same as attachTo)
+		ace_dragging_carryDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 1;  // Cargo space the object takes
+
+		class AE3_Device
+		{
+			displayName = "$STR_AE3_Power_Config_BatteryDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_power_fnc_turnOnBatteryAction";
+			turnOffAction = "_this call AE3_power_fnc_turnOffBatteryAction";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Battery
+			{
+				capacity = 0.6; // 600 Watts/hour max. capacity
+				recharging = 0.3/3600; // 300 Watts power consumption while recharging
+				level = 0.6; // 600 Watts/hour capacity at the beginning
+				internal = 0;
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED SOLAR PANEL OLIVE
+	class Land_SolarPanel_04_olive_F;
+	class Land_SolarPanel_04_olive_F_AE3 : Land_SolarPanel_04_olive_F
+	{
 		// Cargo
 		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
 		ace_cargo_size = 2;  // Cargo space the object takes
@@ -467,9 +381,272 @@ class CfgVehicles
 		};
 	};
 
+	/* ================================================================================ */
 
+	// RUGGED SOLAR PANEL BLACK
+	class Land_SolarPanel_04_black_F;
+	class Land_SolarPanel_04_black_F_AE3 : Land_SolarPanel_04_black_F
+	{
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 2;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Power_Config_SolarPanelDisplayName";
+
+			init = "_this call AE3_interaction_fnc_initSolarPanel;";
+
+			class AE3_aceWorkaround
+			{
+				class AE3_aceDragging
+				{
+					// Dragging
+					ae3_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
+			};
+
+			class AE3_Animations
+			{
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Power_Config_SolarPanel1";
+					selection = "panel_1";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Power_Config_PitchSolarPanel1";
+						animation = "Panel_1_Pitch";
+						minValue = -45;
+						maxValue = 45;
+						scrollMultiplier = 5;
+					};
+				};
+
+				class AE3_Animation_Point_1
+				{
+					description = "$STR_AE3_Power_Config_SolarPanel2";
+					selection = "panel_2";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Power_Config_PitchSolarPanel2";
+						animation = "Panel_2_Pitch";
+						minValue = -45;
+						maxValue = 45;
+						scrollMultiplier = 5;
+					};
+				};
+				
+				class AE3_Animation_Point_2
+				{
+					description = "$STR_AE3_Power_Config_SolarPanelsDisplayName";
+					selection = "panels_base";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Power_Config_YawSolarPanels";
+						animation = "Panels_Yaw";
+						minValue = -180;
+						maxValue = 180;
+						scrollMultiplier = 10;
+					};
+				};
+			};
+		};
+
+		class AE3_Device
+		{
+			displayName = "$STR_AE3_Power_Config_SolarPanelDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_power_fnc_turnOnSolarAction";
+			turnOffAction = "_this call AE3_power_fnc_turnOffSolarAction";
+
+			class AE3_SolarGenerator
+			{
+				powerMax = 0.1/3600; // In this case per panel
+				orientationFnc = "_this call AE3_power_fnc_multSolarPanelOrientation";
+				height = 1.2;
+			};
+		};
+
+		class AE3_InternalDevice
+		{
+			displayName = "$STR_AE3_Power_Config_BatteryDisplayName";
+			defaultPowerLevel = 1;
+
+			turnOnAction = "_this + [true] call AE3_power_fnc_turnOnBatteryAction";
+			turnOffAction = "";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Battery
+			{
+				capacity = 0.4;
+				recharging = 0.05/3600;
+				level = 0;
+				internal = 1;
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
+	// RUGGED SOLAR PANEL SAND
+	class Land_SolarPanel_04_sand_F;
+	class Land_SolarPanel_04_sand_F_AE3 : Land_SolarPanel_04_sand_F
+	{
+		// Cargo
+		ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+		ace_cargo_size = 2;  // Cargo space the object takes
+
+		class AE3_Equipment
+		{
+			displayName = "$STR_AE3_Power_Config_SolarPanelDisplayName";
+
+			init = "_this call AE3_interaction_fnc_initSolarPanel;";
+
+			class AE3_aceWorkaround
+			{
+				class AE3_aceDragging
+				{
+					// Dragging
+					ae3_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+					ae3_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+					ae3_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+				};
+			};
+
+			class AE3_Animations
+			{
+				class AE3_Animation_Point_0
+				{
+					description = "$STR_AE3_Power_Config_SolarPanel1";
+					selection = "panel_1";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Power_Config_PitchSolarPanel1";
+						animation = "Panel_1_Pitch";
+						minValue = -45;
+						maxValue = 45;
+						scrollMultiplier = 5;
+					};
+				};
+
+				class AE3_Animation_Point_1
+				{
+					description = "$STR_AE3_Power_Config_SolarPanel2";
+					selection = "panel_2";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Power_Config_PitchSolarPanel2";
+						animation = "Panel_2_Pitch";
+						minValue = -45;
+						maxValue = 45;
+						scrollMultiplier = 5;
+					};
+				};
+				
+				class AE3_Animation_Point_2
+				{
+					description = "$STR_AE3_Power_Config_SolarPanelsDisplayName";
+					selection = "panels_base";
+
+					class AE3_Animation_Main
+					{
+						description = "$STR_AE3_Power_Config_YawSolarPanels";
+						animation = "Panels_Yaw";
+						minValue = -180;
+						maxValue = 180;
+						scrollMultiplier = 10;
+					};
+				};
+			};
+		};
+
+		class AE3_Device
+		{
+			displayName = "$STR_AE3_Power_Config_SolarPanelDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_power_fnc_turnOnSolarAction";
+			turnOffAction = "_this call AE3_power_fnc_turnOffSolarAction";
+
+			class AE3_SolarGenerator
+			{
+				powerMax = 0.1/3600; // In this case per panel
+				orientationFnc = "_this call AE3_power_fnc_multSolarPanelOrientation";
+				height = 1.2;
+			};
+		};
+
+		class AE3_InternalDevice
+		{
+			displayName = "$STR_AE3_Power_Config_BatteryDisplayName";
+			defaultPowerLevel = 1;
+
+			turnOnAction = "_this + [true] call AE3_power_fnc_turnOnBatteryAction";
+			turnOffAction = "";
+
+			class AE3_PowerInterface
+			{
+				internal = 0;
+			};
+
+			class AE3_Battery
+			{
+				capacity = 0.4;
+				recharging = 0.05/3600;
+				level = 0;
+				internal = 1;
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
+	// FLEXIBLE SOLAR PANEL OLIVE
+	class Land_PortableSolarPanel_01_olive_F;
+	class Land_PortableSolarPanel_01_olive_F_AE3 : Land_PortableSolarPanel_01_olive_F
+	{
+		// Dragging
+        ace_dragging_canDrag = 1;  // Can be dragged (0-no, 1-yes)
+        ace_dragging_dragPosition[] = {0, 1, 0};  // Offset of the model from the body while dragging (same as attachTo)
+        ace_dragging_dragDirection = 0;  // Model direction while dragging (same as setDir after attachTo)
+
+		// Cargo
+        ace_cargo_canLoad = 1;  // Enables the object to be loaded (1-yes, 0-no)
+        ace_cargo_size = 1;  // Cargo space the object takes
+
+		class AE3_Device
+		{
+			displayName = "$STR_AE3_Power_Config_SolarPanelDisplayName";
+			defaultPowerLevel = 0;
+
+			turnOnAction = "_this call AE3_power_fnc_turnOnSolarAction";
+			turnOffAction = "_this call AE3_power_fnc_turnOffSolarAction";
+
+			class AE3_SolarGenerator
+			{
+				powerMax = 0.15/3600;
+				orientationFnc = "[(vectorUp (_this select 0))]";
+				height = 0.1;
+			};
+		};
+	};
+
+	/* ================================================================================ */
+
+	// FLEXIBLE SOLAR PANEL SAND
 	class Land_PortableSolarPanel_01_sand_F;
-
 	class Land_PortableSolarPanel_01_sand_F_AE3 : Land_PortableSolarPanel_01_sand_F
 	{
 		// Dragging


### PR DESCRIPTION
Merging this pull request will revert AE3 class creation to directly inherit from origin classes without overwriting class properties. We've done that in the past to allow changing the texture of placed asset in eden editor, which can be done via the change vehicle texture function. But this comes with some drawbacks, foremost some assets behaved strangly. For example the single rugged lamp stayed in mid-air after lamp was carried instead of falling back to ground (default behavior). Merging this pull request will fix that issue. 