### PR TITLE
changed history to user dependent history

### DIFF
--- a/addons/armaos/functions/fnc_os_history.sqf
+++ b/addons/armaos/functions/fnc_os_history.sqf
@@ -17,7 +17,11 @@ if (count _options >= 1) exitWith { [ _computer, format [localize "STR_AE3_ArmaO
 
 private _terminal = _computer getVariable "AE3_terminal";
 
+private _username = _terminal get "AE3_terminalLoginUser";
+
 private _terminalCommandHistory = _terminal get "AE3_terminalCommandHistory";
+
+_terminalCommandHistory = _terminalCommandHistory get _username;
 
 private _numberedHistory = [];
 {

--- a/addons/armaos/functions/fnc_shell_process.sqf
+++ b/addons/armaos/functions/fnc_shell_process.sqf
@@ -29,13 +29,13 @@ if (!(_commandElements isEqualTo [])) then
 			_pointer = [];
 		};
 
+		[_computer, _commandString] call AE3_armaos_fnc_terminal_addToHistory;
+		_terminal set ["AE3_terminalCommandHistoryIndex", -1];
+
 		[_computer, ""] call AE3_armaos_fnc_terminal_setInputMode;
 		[_computer, _command, _options] call AE3_armaos_fnc_shell_executeFile;
 
 		if (_command == "shutdown") exitWith {};
-
-		[_computer, _commandString] call AE3_armaos_fnc_terminal_addToHistory;
-		_terminal set ["AE3_terminalCommandHistoryIndex", -1];
 	};
 };
 

--- a/addons/armaos/functions/fnc_shell_validatePassword.sqf
+++ b/addons/armaos/functions/fnc_shell_validatePassword.sqf
@@ -38,6 +38,9 @@ if (_userPasswordMatch) then
 
 	_terminal set ["AE3_terminalApplication", "SHELL"];
 
+	private _terminalCommandHistory = _terminal get "AE3_terminalCommandHistory";
+	_terminalCommandHistory getOrDefault [_username, [], true]; // set the user related history, if not existing yet
+
 	if (AE3_DebugMode) then
 	{
 		_computer setVariable ["AE3_filepointer", []];

--- a/addons/armaos/functions/fnc_terminal_addToHistory.sqf
+++ b/addons/armaos/functions/fnc_terminal_addToHistory.sqf
@@ -13,10 +13,12 @@ params ["_computer", "_commandString"];
 
 private _terminal = _computer getVariable "AE3_terminal";
 
+private _username = _terminal get "AE3_terminalLoginUser";
+
 private _terminalCommandHistory = _terminal get "AE3_terminalCommandHistory";
 
-_terminalCommandHistory append [_commandString];
+_terminalCommandHistory = _terminalCommandHistory get _username;
 
-_terminal set ["AE3_terminalCommandHistory", _terminalCommandHistory];
+_terminalCommandHistory pushBack _commandString;
 
 _computer setVariable ["AE3_terminal", _terminal];

--- a/addons/armaos/functions/fnc_terminal_init.sqf
+++ b/addons/armaos/functions/fnc_terminal_init.sqf
@@ -48,7 +48,7 @@ private _terminal = createHashMapFromArray
 		["AE3_terminalScrollPosition", 0],
 		["AE3_terminalCursorLine", 0],
 		["AE3_terminalCursorPosition", 0],
-		["AE3_terminalCommandHistory", []],
+		["AE3_terminalCommandHistory", createHashMap],
 		["AE3_terminalCommandHistoryIndex", -1],
 		["AE3_terminalComputer", _computer],
 		["AE3_terminalPrompt", "/>"],

--- a/addons/armaos/functions/fnc_terminal_setCommandLineByHistory.sqf
+++ b/addons/armaos/functions/fnc_terminal_setCommandLineByHistory.sqf
@@ -16,6 +16,8 @@ params ["_computer", "_key"];
 
 private _terminal = _computer getVariable "AE3_terminal";
 
+private _username = _terminal get "AE3_terminalLoginUser";
+
 private _terminalBuffer = _terminal get "AE3_terminalBuffer";
 private _terminalPrompt = _terminal get "AE3_terminalPrompt";
 
@@ -23,6 +25,7 @@ private _lastBufferLineIndex = (count _terminalBuffer) - 1;
 private _lastBufferLine = "";
 
 private _terminalCommandHistory = _terminal get "AE3_terminalCommandHistory";
+_terminalCommandHistory = _terminalCommandHistory get _username;
 private _terminalCommandHistoryIndex = _terminal get "AE3_terminalCommandHistoryIndex";
 
 private _terminalCommandHistoryLength = count _terminalCommandHistory;


### PR DESCRIPTION
At the moment our history is not user dependent. All users share one history. That's a security issue. By merging this pull request a separate history is saved for every user. It's no more an Array but a HashMap of Arrays with the username as the key. I have successfully tested this in dedicated multiplayer. 