### PR TITLE
Change default IP address for routers

### DIFF
--- a/addons/network/functions/fnc_connect_isCyclic.sqf
+++ b/addons/network/functions/fnc_connect_isCyclic.sqf
@@ -11,8 +11,6 @@
 
 params['_entity', '_cmp'];
 
-systemChat (format ["%1 - %2", _entity, _cmp]);
-
 private _result = false;
 
 {

--- a/addons/network/functions/fnc_initRouter.sqf
+++ b/addons/network/functions/fnc_initRouter.sqf
@@ -12,7 +12,7 @@
  *
  */
 
-params["_entity", ["_parent", objNull], ["_address", [168, 178, 0, 1]], ["_internal", false]];
+params["_entity", ["_parent", objNull], ["_address", [192, 168, 0, 1]], ["_internal", false]];
 
 
 private _childs = 


### PR DESCRIPTION
Prio to that pull request the default IP address was very unusual and not a private IP address. With this pull request the default IP address is changed to a very common 192.168.0.1