### PR TITLE
Turn on/off progress bar cancellation for generator and solar panel

### DIFF
--- a/addons/power/functions/fnc_turnOffGeneratorAction.sqf
+++ b/addons/power/functions/fnc_turnOffGeneratorAction.sqf
@@ -67,7 +67,7 @@ else
 {
 	[_entity] call _turnOffGenFunc;
 
-	_return = true;
+	_result = true;
 };
 
 // function immediately returns false, because progress bar runs unscheduled

--- a/addons/power/functions/fnc_turnOffGeneratorAction.sqf
+++ b/addons/power/functions/fnc_turnOffGeneratorAction.sqf
@@ -49,7 +49,7 @@ if (!_silent) then
 			_entity setVariable ["AE3_power_powerState", 0, true];
 		},
 		{
-			// following code only runs on progress bar success
+			// following code only runs on progress bar fail
 			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
 			
 			_args params ["_entity", "_stopSoundHandle", "_turnOffGenFunc"];

--- a/addons/power/functions/fnc_turnOffGeneratorAction.sqf
+++ b/addons/power/functions/fnc_turnOffGeneratorAction.sqf
@@ -8,35 +8,67 @@
  * Return:
  * None
 */
+
 params ["_entity", ["_silent", false]];
 
-_powerState = _entity getVariable "AE3_power_powerState";
+private _result = false;
 
-_turnOffTime = 3;
+private _turnOffTime = 3;
 
-_handle = [_entity] spawn AE3_power_fnc_playGeneratorStopSound;
+private _stopSoundHandle = [_entity] spawn AE3_power_fnc_playGeneratorStopSound;
 
+private _turnOffGenFunc =
+{
+	params ["_entity"];
+
+	[_entity, true, [0, 1, 0], 0] call ace_dragging_fnc_setDraggable;
+
+	[_entity] remoteExecCall ["AE3_power_fnc_removeProviderHandler", 2];
+
+	// TODO: Wrapper?
+	{
+			[_x] call (_x getVariable "AE3_power_fnc_turnOffWrapper");
+	}forEach (_entity getVariable ["AE3_power_connectedDevices", []]);
+};
 
 if (!_silent) then 
 {
 	[
 		_turnOffTime,
-		[_entity], 
+		[_entity, _stopSoundHandle, _turnOffGenFunc], 
 		{
+			// following code only runs on progress bar success
+			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
+			
+			_args params ["_entity", "_stopSoundHandle", "_turnOffGenFunc"];
 
+			[_entity] call _turnOffGenFunc;
+
+			// we need to set power state here because function already returned false
+			// and therefore the turn on wrapper doesn't set the state to turned on
+			_entity setVariable ["AE3_power_powerState", 0, true];
 		},
-		{},
-		(localize "STR_AE3_Power_Interaction_TurnOff")
+		{
+			// following code only runs on progress bar success
+			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
+			
+			_args params ["_entity", "_stopSoundHandle", "_turnOffGenFunc"];
+
+			// stop sound will be canceled
+			terminate _stopSoundHandle;
+
+			// start sound will be played
+			private _stopSoundHandle = [_entity] spawn AE3_power_fnc_playGeneratorStartSound;			
+		},
+		(localize "STR_AE3_Power_Interaction_TurnOff" + "...")
 	] call ace_common_fnc_progressBar;
+}
+else
+{
+	[_entity] call _turnOffGenFunc;
+
+	_return = true;
 };
 
-[_entity, true, [0, 1, 0], 0] call ace_dragging_fnc_setDraggable;
-
-[_entity] remoteExecCall ["AE3_power_fnc_removeProviderHandler", 2];
-
-// TODO: Wrapper?
-{
-		[_x] call (_x getVariable 'AE3_power_fnc_turnOffWrapper');
-}forEach (_entity getVariable ['AE3_power_connectedDevices', []]);
-
-true;
+// function immediately returns false, because progress bar runs unscheduled
+_result;

--- a/addons/power/functions/fnc_turnOffSolarAction.sqf
+++ b/addons/power/functions/fnc_turnOffSolarAction.sqf
@@ -8,30 +8,61 @@
  * Return:
  * None
 */
+
 params ["_entity", ["_silent", false]];
+
+private _result = false;
+
+private _turnOffTime = 3;
+
+private _turnOffSolPanFunc =
+{
+	params ["_entity"];
+
+	[_entity, true, [0, 1, 0], 0] call ace_dragging_fnc_setDraggable;
+
+	[_entity] remoteExecCall ["AE3_power_fnc_removeProviderHandler", 2];
+
+	// TODO: Wrapper?
+	{
+			[_x] call (_x getVariable "AE3_power_fnc_turnOffWrapper");
+	}forEach (_entity getVariable ["AE3_power_connectedDevices", []]);
+
+	_entity setVariable ["AE3_power_powerCapacity", 0, 2];
+};
 
 if (!_silent) then 
 {
 	[
-		3,
-		[_entity], 
+		_turnOffTime,
+		[_entity, _turnOffSolPanFunc], 
 		{
+			// following code only runs on progress bar success
+			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
+			
+			_args params ["_entity", "_turnOffSolPanFunc"];
 
+			[_entity] call _turnOffSolPanFunc;
+
+			// we need to set power state here because function already returned false
+			// and therefore the turn on wrapper doesn't set the state to turned on
+			_entity setVariable ["AE3_power_powerState", 0, true];
 		},
-		{},
-		(localize "STR_AE3_Power_Interaction_TurnOff")
+		{
+			// following code only runs on progress bar success
+			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
+			
+			_args params ["_entity", "_turnOffSolPanFunc"];
+		},
+		(localize "STR_AE3_Power_Interaction_TurnOff" + "...")
 	] call ace_common_fnc_progressBar;
+}
+else
+{
+	[_entity] call _turnOffSolPanFunc;
+
+	_result = true;
 };
 
-[_entity, true, [0, 1, 0], 0] call ace_dragging_fnc_setDraggable;
-
-[_entity] remoteExecCall ["AE3_power_fnc_removeProviderHandler", 2];
-
-// TODO: Wrapper?
-{
-		[_x] call (_x getVariable 'AE3_power_fnc_turnOffWrapper');
-}forEach (_entity getVariable ['AE3_power_connectedDevices', []]);
-
-_entity setVariable ['AE3_power_powerCapacity', 0, 2];
-
-true;
+// function immediately returns false, because progress bar runs unscheduled
+_result;

--- a/addons/power/functions/fnc_turnOffSolarAction.sqf
+++ b/addons/power/functions/fnc_turnOffSolarAction.sqf
@@ -49,10 +49,7 @@ if (!_silent) then
 			_entity setVariable ["AE3_power_powerState", 0, true];
 		},
 		{
-			// following code only runs on progress bar success
-			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
-			
-			_args params ["_entity", "_turnOffSolPanFunc"];
+			// following code only runs on progress bar fail
 		},
 		(localize "STR_AE3_Power_Interaction_TurnOff" + "...")
 	] call ace_common_fnc_progressBar;

--- a/addons/power/functions/fnc_turnOnGeneratorAction.sqf
+++ b/addons/power/functions/fnc_turnOnGeneratorAction.sqf
@@ -10,31 +10,50 @@
 
 params ["_entity"];
 
-private _fuelCapacity = _entity getVariable 'AE3_power_fuelCapacity';
+private _fuelCapacity = _entity getVariable "AE3_power_fuelCapacity";
 private _fuelLevelPercent = fuel _entity;
 private _fuelLevel = _fuelCapacity * _fuelLevelPercent;
 
+private _result = false;
+
 if (_fuelLevel > 0) then
 {
-	_turnOnTime = 5;
+	private _turnOnTime = 5;
 
-	_handle = [_entity] spawn AE3_power_fnc_playGeneratorStartSound;
+	private _startSoundHandle = [_entity] spawn AE3_power_fnc_playGeneratorStartSound;
 
 	[
 		_turnOnTime,
-		[_entity], 
+		[_entity, _startSoundHandle], 
 		{
+			// following code only runs on progress bar success
 			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
 			
-			_entity = _args select 0;
+			_args params ["_entity", "_startSoundHandle"];
 
 			[_entity, AE3_power_fnc_fuelConsumption] remoteExecCall ["AE3_power_fnc_addProviderHandler", 2];
 
 			[_entity, false, [0, 1, 0], 0] call ace_dragging_fnc_setDraggable;
+
+			// we need to set power state here because function already returned false
+			// and therefore the turn on wrapper doesn't set the state to turned on
+			_entity setVariable ["AE3_power_powerState", 1, true];
 		},
-		{},
-		(localize "STR_AE3_Power_Interaction_TurnOn")
+		{
+			// following code only runs on progress bar fail
+			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
+
+			_args params ["_entity", "_startSoundHandle"];
+			
+			// start sound will be canceled
+			terminate _startSoundHandle;
+
+			// stop sound will be played
+			private _stopSoundHandle = [_entity] spawn AE3_power_fnc_playGeneratorStopSound;
+		},
+		(localize "STR_AE3_Power_Interaction_TurnOn" + "...")
 	] call ace_common_fnc_progressBar;
 };
 
-true;
+// function immediately returns false, because progress bar runs unscheduled
+_result;

--- a/addons/power/functions/fnc_turnOnSolarAction.sqf
+++ b/addons/power/functions/fnc_turnOnSolarAction.sqf
@@ -2,7 +2,7 @@
  * Turns on the solar panel.
  *
  * Arguments:
- * 0: Generator <OBJECT>
+ * 0: Solar Panel <OBJECT>
  *
  * Returns:
  * None
@@ -10,20 +10,35 @@
 
 params ["_entity"];
 
+private _result = false;
+
+private _turnOnTime = 3;
+
 [
-3,
-[_entity], 
-{
-	params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
-	
-	_entity = _args select 0;
+	_turnOnTime,
+	[_entity], 
+	{
+		// following code only runs on progress bar success
+		params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
+		
+		_args params ["_entity"];
 
-	[_entity, AE3_power_fnc_solarCalculation] remoteExecCall ["AE3_power_fnc_addProviderHandler", 2];
+		[_entity, AE3_power_fnc_solarCalculation] remoteExecCall ["AE3_power_fnc_addProviderHandler", 2];
 
-	[_entity, false, [0, 1, 0], 0] call ace_dragging_fnc_setDraggable;
-},
-{},
-(localize "STR_AE3_Power_Interaction_TurnOn")
+		[_entity, false, [0, 1, 0], 0] call ace_dragging_fnc_setDraggable;
+
+		// we need to set power state here because function already returned false
+		// and therefore the turn on wrapper doesn't set the state to turned on
+		_entity setVariable ["AE3_power_powerState", 1, true];
+	},
+	{
+		// following code only runs on progress bar fail
+		params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
+		
+		_args params ["_entity"];
+	},
+	(localize "STR_AE3_Power_Interaction_TurnOn" + "...")
 ] call ace_common_fnc_progressBar;
 
-true;
+// function immediately returns false, because progress bar runs unscheduled
+_result;

--- a/addons/power/functions/fnc_turnOnSolarAction.sqf
+++ b/addons/power/functions/fnc_turnOnSolarAction.sqf
@@ -33,9 +33,6 @@ private _turnOnTime = 3;
 	},
 	{
 		// following code only runs on progress bar fail
-		params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
-		
-		_args params ["_entity"];
 	},
 	(localize "STR_AE3_Power_Interaction_TurnOn" + "...")
 ] call ace_common_fnc_progressBar;


### PR DESCRIPTION
At the moment if the ACE3 progress bar for turning on/off generator or solar panel is cancelled, the setup is in an undefined state because some code like setting the on/off state is set although the action was cancelled.

By merging this pull request this issue is fixed. Now It's possible to cancel the progress bars. It's not a very elegant solution because we are switching from unscheduled to scheduled execution and therefore the handling of the return value is a problem. But I think the workaround is ok.

Another solution would be getting rid the progress bar at all. I don't think that the solar panel needs a progress bar. It could be turned on/off immediately. Also the generator doesn't need a interruptable stop/stop procedure. I think it's more like pressing a button. The start and stop sounds are only for immersion.