### PR TITLE
Disable empty login string in debug mode and apply filter

### DIFF
--- a/addons/armaos/functions/fnc_shell_findLoginUser.sqf
+++ b/addons/armaos/functions/fnc_shell_findLoginUser.sqf
@@ -18,7 +18,14 @@ private _users = _computer getVariable ["AE3_Userlist", createHashMap];
 private _result = [];
 private _logMessage = "";
 
-if ((_username in _users) || AE3_DebugMode) then 
+if (AE3_DebugMode) then
+{
+	private _debugUsername = [_username] call BIS_fnc_filterString; // (default filter a..z, A..Z, 0..9, "_")
+	// no empty string allowed or changing an existing username
+	if (((count _debugUsername) > 0) && !(_username in _users)) then { _username = _debugUsername; };
+};
+
+if ((_username in _users) || AE3_DebugMode) then
 {
 	_terminal set ["AE3_terminalLoginUser", _username];
 	_terminal set ["AE3_terminalApplication", "PASSWORD"];

--- a/addons/armaos/stringtable.xml
+++ b/addons/armaos/stringtable.xml
@@ -122,25 +122,25 @@
                 <Russian>root login disabled</Russian>
             </Key>
             <Key ID="STR_AE3_ArmaOS_Exception_UserNotFound">
-                <Original>User: %1 not found</Original>
-                <English>User: %1 not found</English>
-                <German>Benutzer: %1 nicht gefunden</German>
-                <Chinesesimp>未找到用户: %1</Chinesesimp>
-                <Russian>Пользователь: %1 не найден</Russian>
+                <Original>User: '%1' not found</Original>
+                <English>User: '%1' not found</English>
+                <German>Benutzer: '%1' nicht gefunden</German>
+                <Chinesesimp>未找到用户: '%1'</Chinesesimp>
+                <Russian>Пользователь: '%1' не найден</Russian>
             </Key>
             <Key ID="STR_AE3_ArmaOS_Exception_UserFailedLogin">
-                <Original>User: %1 failed login attempt</Original>
-                <English>User: %1 failed login attempt</English>
-                <German>Benutzer: %1 fehlgeschlagener Login-Versuch</German>
-                <Chinesesimp>用户: %1 尝试登陆失败</Chinesesimp>
-                <Russian>Пользователь: %1 неудачная попытка входа</Russian>
+                <Original>User: '%1' failed login attempt</Original>
+                <English>User: '%1' failed login attempt</English>
+                <German>Benutzer: '%1' fehlgeschlagener Login-Versuch</German>
+                <Chinesesimp>用户: '%1' 尝试登陆失败</Chinesesimp>
+                <Russian>Пользователь: '%1' неудачная попытка входа</Russian>
             </Key>
             <Key ID="STR_AE3_ArmaOS_Exception_UserLoginSuccessful">
-                <Original>User: %1 successfully logged in</Original>
-                <English>User: %1 successfully logged in</English>
-                <German>Benutzer: %1 erfolgreich eingeloggt</German>
-                <Chinesesimp>用户: %1 登陆成功</Chinesesimp>
-                <Russian>Пользователь: %1 успешно вошел в систему</Russian>
+                <Original>User: '%1' successfully logged in</Original>
+                <English>User: '%1' successfully logged in</English>
+                <German>Benutzer: '%1' erfolgreich eingeloggt</German>
+                <Chinesesimp>用户: '%1' 登陆成功</Chinesesimp>
+                <Russian>Пользователь: '%1' успешно вошел в систему</Russian>
             </Key>
             <Key ID="STR_AE3_ArmaOS_Exception_DialogFailed">
                 <Original>Dialog couldn't be opened!</Original>


### PR DESCRIPTION
Prior to this pull request logins in debug mode with empty strings or strings containing blanks and special characters are allowed.

Merging this Pull Request will add a check for empty strings and applies a filter (a..z, A..Z, 0..9, "_") to debug mode usernames, but only if the entered username is not a legal username in this particular armaOS instance.