### PR TITLE
Fixed armaOS use delay

### DIFF
--- a/addons/armaos/functions/fnc_computer_playSoundStart.sqf
+++ b/addons/armaos/functions/fnc_computer_playSoundStart.sqf
@@ -16,4 +16,3 @@ private _distance = 50;
 private _volume = 5;
 
 playSound3D [_filename, _computer, _isInside, getPos _computer, _volume, 1, _distance, 0];
-sleep 5;


### PR DESCRIPTION
If you bootup a laptop and the startup sound appears there is still a 5 sec. delay, before the ACE3 Interaction to use armaOS appears. This is because the turnOn function runs in scheduled environment. So every called function also runs in scheduled environment. Therefore the `sleep 5;` in the playSoundStart function has an effect and pauses the execution. By merging this Pull Request we get rid of that command, because I see no need for that.