### PR TITLE
armaOS accessable while sitting on chair

### DIFF
--- a/addons/armaos/CfgVehicles.hpp
+++ b/addons/armaos/CfgVehicles.hpp
@@ -77,38 +77,6 @@ class CfgVehicles
 				internal = 1;
 			};
 		};
-
-		
-        class ACE_Actions 
-		{
-			class ACE_MainActions
-			{
-				displayName = "$STR_ACE_Interaction_MainAction";
-				condition = "true";
-				distance = 2;
-				class AE3_Laptop_Group
-				{
-					displayName = "$STR_AE3_ArmaOS_Config_ArmaOSDisplayName";
-					condition = "true";
-					class AE3_UseComputer
-					{
-						displayName = "$STR_AE3_ArmaOS_Config_UseDisplayName";
-						condition = "(alive _target) && (_target getVariable 'AE3_power_powerState' == 1) && (isNull (_target getVariable ['AE3_computer_mutex', objNull]))";
-						statement = "params ['_target', '_player', '_params']; _target setVariable ['AE3_computer_mutex', _player, true]; _handle = [_target] spawn AE3_armaos_fnc_terminal_init;";
-						//icon = "\z\dance.paa";
-						exceptions[] = {};
-						//insertChildren
-						//modifierFunction
-						//runOnHover
-						//distance
-						//position
-						//selection
-						priority = -1;
-						showDisabled = 0;
-					};
-				};
-			};
-		};
 	};
 
 	/* ================================================================================ */
@@ -188,38 +156,6 @@ class CfgVehicles
 				internal = 1;
 			};
 		};
-
-		
-        class ACE_Actions 
-		{
-			class ACE_MainActions
-			{
-				displayName = "$STR_ACE_Interaction_MainAction";
-				condition = "true";
-				distance = 2;
-				class AE3_Laptop_Group
-				{
-					displayName = "$STR_AE3_ArmaOS_Config_ArmaOSDisplayName";
-					condition = "true";
-					class AE3_UseComputer
-					{
-						displayName = "$STR_AE3_ArmaOS_Config_UseDisplayName";
-						condition = "(alive _target) && (_target getVariable 'AE3_power_powerState' == 1) && (isNull (_target getVariable ['AE3_computer_mutex', objNull]))";
-						statement = "params ['_target', '_player', '_params']; _target setVariable ['AE3_computer_mutex', _player, true]; _handle = [_target] spawn AE3_armaos_fnc_terminal_init;";
-						//icon = "\z\dance.paa";
-						exceptions[] = {};
-						//insertChildren
-						//modifierFunction
-						//runOnHover
-						//distance
-						//position
-						//selection
-						priority = -1;
-						showDisabled = 0;
-					};
-				};
-			};
-		};
 	};
 
 	/* ================================================================================ */
@@ -297,38 +233,6 @@ class CfgVehicles
 				recharging = 0.05/3600; // 50 Watts power consumption while recharging
 				level = 0.1; // 100 Watts/hour capacity at the beginning
 				internal = 1;
-			};
-		};
-
-		
-        class ACE_Actions 
-		{
-			class ACE_MainActions
-			{
-				displayName = "$STR_ACE_Interaction_MainAction";
-				condition = "true";
-				distance = 2;
-				class AE3_Laptop_Group
-				{
-					displayName = "$STR_AE3_ArmaOS_Config_ArmaOSDisplayName";
-					condition = "true";
-					class AE3_UseComputer
-					{
-						displayName = "$STR_AE3_ArmaOS_Config_UseDisplayName";
-						condition = "(alive _target) && (_target getVariable 'AE3_power_powerState' == 1) && (isNull (_target getVariable ['AE3_computer_mutex', objNull]))";
-						statement = "params ['_target', '_player', '_params']; _target setVariable ['AE3_computer_mutex', _player, true]; _handle = [_target] spawn AE3_armaos_fnc_terminal_init;";
-						//icon = "\z\dance.paa";
-						exceptions[] = {};
-						//insertChildren
-						//modifierFunction
-						//runOnHover
-						//distance
-						//position
-						//selection
-						priority = -1;
-						showDisabled = 0;
-					};
-				};
 			};
 		};
 	};

--- a/addons/interaction/functions/fnc_initLaptop.sqf
+++ b/addons/interaction/functions/fnc_initLaptop.sqf
@@ -1,5 +1,5 @@
 /**
- * Initializes a laptop, especially the initially open/closed animation phase.
+ * Initializes a laptop, especially the initially open/closed animation phase and the interaction menu.
  *
  * Arguments:
  * 0: Laptop <OBJECT>
@@ -10,11 +10,42 @@
 
 params["_laptop"];
 
-if (_laptop getVariable 'AE3_interaction_closeState' == 1) then
+// init the open/close state of the laptop
+if (_laptop getVariable "AE3_interaction_closeState" == 1) then
 {
     [_laptop] call (_laptop getVariable "AE3_interaction_fnc_close");
 }
 else
 {
     [_laptop] call (_laptop getVariable "AE3_interaction_fnc_open");
+};
+
+if(!isDedicated) then
+{
+    // add the armaOS Menu to ACE3 Interaction Menu
+    private _armaOSAction = ["AE3_ArmaOSAction", localize "STR_AE3_ArmaOS_Config_ArmaOSDisplayName", "", {}, {true}] call ace_interact_menu_fnc_createAction;
+    [_laptop, 0, ["ACE_MainActions"], _armaOSAction] call ace_interact_menu_fnc_addActionToObject;
+
+    // add the 'use' interaction to the armaOS Menu
+    private _useAction =
+    [
+        "AE3_UseAction", // internal name
+        localize "STR_AE3_ArmaOS_Config_UseDisplayName", // visable name
+        "", // icon
+        {
+            // statement
+            params ["_target", "_player", "_params"];
+
+            _target setVariable ["AE3_computer_mutex", _player, true];
+            _handle = [_target] spawn AE3_armaos_fnc_terminal_init;
+        }, 
+        {
+            // condition
+            params ["_target", "_player", "_params"];
+
+            (alive _target) && (_target getVariable "AE3_power_powerState" == 1) &&
+            (isNull (_target getVariable ["AE3_computer_mutex", objNull]))
+        }
+    ] call ace_interact_menu_fnc_createAction;
+    [_laptop, 0, ["ACE_MainActions", "AE3_ArmaOSAction"], _useAction] call ace_interact_menu_fnc_addActionToObject; // 0 = action; 1 = self-action
 };


### PR DESCRIPTION
Merging this PR will change the ACE Interaction for the laptop. It's now defined in init script and not in config. This allows the player to access armaOS while sitting on a chair with ACE3 sitting. The creation of the action via config seems to prevent that. I don't know why but this fixes the issue.

Now the ACE3 interactions in all places are all defined via script and not via config.