### PR TITLE
ACE3 Progress Bar for opening/closing rugged desks

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -1757,8 +1757,8 @@ class CfgVehicles
 
 			init = "_this call AE3_interaction_fnc_initDesk;";
 
-			openAction = "_this call AE3_interaction_fnc_desk_open;";
-			closeAction = "_this call AE3_interaction_fnc_desk_close;";
+			openAction = "_this call AE3_interaction_fnc_start_desk_open;";
+			closeAction = "_this call AE3_interaction_fnc_start_desk_close;";
 
 			class AE3_Animations
 			{
@@ -1875,8 +1875,8 @@ class CfgVehicles
 
 			init = "_this call AE3_interaction_fnc_initDesk;";
 
-			openAction = "_this call AE3_interaction_fnc_desk_open;";
-			closeAction = "_this call AE3_interaction_fnc_desk_close;";
+			openAction = "_this call AE3_interaction_fnc_start_desk_open;";
+			closeAction = "_this call AE3_interaction_fnc_start_desk_close;";
 
 			class AE3_Animations
 			{
@@ -1993,8 +1993,8 @@ class CfgVehicles
 
 			init = "_this call AE3_interaction_fnc_initDesk;";
 
-			openAction = "_this call AE3_interaction_fnc_desk_open;";
-			closeAction = "_this call AE3_interaction_fnc_desk_close;";
+			openAction = "_this call AE3_interaction_fnc_start_desk_open;";
+			closeAction = "_this call AE3_interaction_fnc_start_desk_close;";
 
 			class AE3_Animations
 			{

--- a/addons/interaction/XEH_PREP.hpp
+++ b/addons/interaction/XEH_PREP.hpp
@@ -10,6 +10,8 @@ PREP(laptop_open);
 PREP(laptop_close);
 PREP(desk_open);
 PREP(desk_close);
+PREP(start_desk_open);
+PREP(start_desk_close);
 
 /* Compile */
 PREP(compileConfig);

--- a/addons/interaction/functions/fnc_start_desk_close.sqf
+++ b/addons/interaction/functions/fnc_start_desk_close.sqf
@@ -1,0 +1,23 @@
+/**
+ * Starts process of closing a desk
+ *
+ * Arguments:
+ * 0: Desk <OBJECT>
+ *
+ * Return Value:
+ * None
+*/
+
+params ['_desk'];
+
+[
+	15, // time in seconds
+	_desk, // arguments for Finish + fail
+	{ // on finish
+		[_this] call AE3_interaction_fnc_desk_close;
+	},
+	{}, // on fail
+	"Closing desk" // progress bar text, can be localized
+	{true}, // condition code checked each frame to continue
+	["isNotSwimming"] // conditions for checking interaction
+] call ace_common_fnc_progressBar;

--- a/addons/interaction/functions/fnc_start_desk_open.sqf
+++ b/addons/interaction/functions/fnc_start_desk_open.sqf
@@ -1,0 +1,23 @@
+/**
+ * Starts process of opening a desk
+ *
+ * Arguments:
+ * 0: Desk <OBJECT>
+ *
+ * Return Value:
+ * None
+*/
+
+params ['_desk'];
+
+[
+	15, // time in seconds
+	_desk, // arguments for Finish + fail
+	{ // on finish
+		[_this] call AE3_interaction_fnc_desk_open;
+	},
+	{}, // on fail
+	"Opening desk" // progress bar text, can be localized
+	{true}, // condition code checked each frame to continue
+	["isNotSwimming"] // conditions for checking interaction
+] call ace_common_fnc_progressBar;


### PR DESCRIPTION
#116
https://github.com/acemod/ACE3/blob/master/addons/common/functions/fnc_progressBar.sqf

Changes open/close action of AE desks to enter start-open/start-close wrapper that provides progressBar. Customize conditions as desired