### PR TITLE
getOpts Syntax Check

### DIFF
--- a/addons/armaos/XEH_PREP.hpp
+++ b/addons/armaos/XEH_PREP.hpp
@@ -18,7 +18,7 @@ PREP(shell_getOptsParseLongForm);
 PREP(shell_getOptsParseShortForm);
 PREP(shell_getOptsPrintHelp);
 PREP(shell_getOptsSplitOptionArgument);
-
+PREP(shell_getOptsCheckSyntax);
 
 /* Computer Functions */
 PREP(computer_playSoundStart);

--- a/addons/armaos/functions/fnc_os_crack.sqf
+++ b/addons/armaos/functions/fnc_os_crack.sqf
@@ -22,7 +22,7 @@ private _commandSyntax =
 	[
 			["command", _commandName, true, false],
             ["options", "OPTIONS", true, false],
-			["path", "MESSAGE", true, false]
+			["path", "MESSAGE", true, true]
 	]
 ];
 private _commandSettings = [_commandName, _commandOpts, _commandSyntax];

--- a/addons/armaos/functions/fnc_os_crypto.sqf
+++ b/addons/armaos/functions/fnc_os_crypto.sqf
@@ -24,7 +24,7 @@ private _commandSyntax =
 	[
 			["command", _commandName, true, false],
             ["options", "OPTIONS", true, false],
-			["path", "MESSAGE", true, false]
+			["path", "MESSAGE", true, true]
 	]
 ];
 private _commandSettings = [_commandName, _commandOpts, _commandSyntax];

--- a/addons/armaos/functions/fnc_os_echo.sqf
+++ b/addons/armaos/functions/fnc_os_echo.sqf
@@ -21,7 +21,7 @@ private _commandSyntax =
 	[
 			["command", _commandName, true, false],
 			["options", "OPTIONS", false, false],
-            ["path", "TEXTLINE", true, false]
+            ["path", "TEXT", true, true]
 	]
 ];
 private _commandSettings = [_commandName, _commandOpts, _commandSyntax];

--- a/addons/armaos/functions/fnc_os_ls.sqf
+++ b/addons/armaos/functions/fnc_os_ls.sqf
@@ -22,7 +22,7 @@ private _commandSyntax =
 	[
 			["command", _commandName, true, false],
 			["options", "OPTIONS", false, false],
-			["path", "DIRECTORIES", true, true]
+			["path", "DIRECTORIES", false, true]
 	]
 ];
 private _commandSettings = [_commandName, _commandOpts, _commandSyntax];

--- a/addons/armaos/functions/fnc_shell_getOpts.sqf
+++ b/addons/armaos/functions/fnc_shell_getOpts.sqf
@@ -100,6 +100,14 @@ _resultOpts set ["_ae3OptsSuccess", true];
 	};
 } forEach _requiredOpts;
 
+private _syntaxMatch = [_commandSyntax, _resultThings] call AE3_armaos_fnc_shell_getOptsCheckSyntax;
+
+if (!_syntaxMatch) then
+{
+	_resultOpts set ["_ae3OptsSuccess", false];
+	[_computer, format ["Syntax mismatch! See output of '%1 -h' for allowed syntax.", _commandName]] call AE3_armaos_fnc_shell_stdout;
+};
+
 _result = _resultOpts toArray false; // Convert HashMap to Array
 
 _result;

--- a/addons/armaos/functions/fnc_shell_getOptsCheckSyntax.sqf
+++ b/addons/armaos/functions/fnc_shell_getOptsCheckSyntax.sqf
@@ -27,7 +27,7 @@ private _thingsCountVariants = [];
 	// for all syntax variants ...
 	
 	private _thingsCountMin = 0;
-	private _thingsCountMax = -1;
+	private _thingsCountMax = 0;
 
 	private _syntaxVariant = _x;
 	
@@ -61,10 +61,6 @@ private _thingsCountVariants = [];
         if (_elementCountUnlimited) then
         {
             _thingsCountMax = -1;
-        }
-        else
-        {
-            _thingsCountMax = _thingsCountMax + 1;
         };
 
         if (_elementRequired && !_elementCountUnlimited && (_thingsCountMax != -1)) then
@@ -74,18 +70,18 @@ private _thingsCountVariants = [];
 
 	} forEach _syntaxVariant;
 	
-	_thingsCountVariants pushBack _thingsCount;   
+	_thingsCountVariants pushBack [_thingsCountMin, _thingsCountMax];   
 
 } forEach _syntax;
 
 private _currentThingsCount = count _things;
 
 {
+    _x params ["_min", "_max"];
+
 	// the current count only needs to match one syntax variant
-	if (_currentThingsCount == _x) exitWith { _result = true; };
+	if ((_currentThingsCount >= _min) && ((_currentThingsCount <= _max) || (_max == -1))) exitWith { _result = true; };
 	
-	// with unlimited count allowed there only needs to be one element as a minimum
-	if ((_x == -1) && (_currentThingsCount >= 1)) exitWith { _result = true; };
 } forEach _thingsCountVariants;
 
 _result;

--- a/addons/armaos/functions/fnc_shell_getOptsCheckSyntax.sqf
+++ b/addons/armaos/functions/fnc_shell_getOptsCheckSyntax.sqf
@@ -1,0 +1,91 @@
+/**
+ * checks the amount of things against the defined syntax
+ *
+ * Arguments:
+ * 1: Syntax <[ARRAY]>
+ * 2: Things <[STRING]>
+ *
+ * Results:
+ * 1: Result <BOOLEAN>
+ *
+ * See AE3 wiki on how to you this in your own commands and applications
+ *
+ * things count conventions:
+ * 0 = no things
+ * -1 = unlimited things, minimum 1
+ * 1-X = exact number of things
+ *
+ */
+
+params ["_syntax", "_things"];
+
+private _result = false;
+
+private _thingsCountVariants = [];
+
+{
+	// for all syntax variants ...
+	
+	private _thingsCountMin = 0;
+	private _thingsCountMax = -1;
+
+	private _syntaxVariant = _x;
+	
+	{
+		// ... calculate the expected things count
+		
+		private _elementType = _x select 0;
+		private _elementRequired = _x select 2;
+		private _elementCountUnlimited = _x select 3;
+		
+		if (_forEachIndex == 0) then { continue; }; // skip loop iteration for 1st element, which is the command itself
+		if (_elementType isEqualTo "options") then { continue; }; // skip loop iteration for options element
+
+        //
+        // decision matrix
+        //
+        // required | unlimited | _thingsCountMin | _thingsCountMax
+        // --------------------------------------------------------
+        // true     | true      | + 1             | set to -1
+        // true     | false     | + 1             | + 1, if not already set to -1
+        // false    | true      | ---             | set to -1
+        // false    | false     | ---             | ---
+        // --------------------------------------------------------
+        //
+
+		if (_elementRequired) then
+        {
+            _thingsCountMin = _thingsCountMin + 1;
+        };
+
+        if (_elementCountUnlimited) then
+        {
+            _thingsCountMax = -1;
+        }
+        else
+        {
+            _thingsCountMax = _thingsCountMax + 1;
+        };
+
+        if (_elementRequired && !_elementCountUnlimited && (_thingsCountMax != -1)) then
+        {
+            _thingsCountMax = _thingsCountMax + 1;
+        };
+
+	} forEach _syntaxVariant;
+	
+	_thingsCountVariants pushBack _thingsCount;   
+
+} forEach _syntax;
+
+private _currentThingsCount = count _things;
+
+{
+	// the current count only needs to match one syntax variant
+	if (_currentThingsCount == _x) exitWith { _result = true; };
+	
+	// with unlimited count allowed there only needs to be one element as a minimum
+	if ((_x == -1) && (_currentThingsCount >= 1)) exitWith { _result = true; };
+} forEach _thingsCountVariants;
+
+_result;


### PR DESCRIPTION
Merging this PR will add a Syntax check to every command. This check analyses the syntax definitions of every command and calculates a minimum and a maximum amount of "things" that could/should appear after command itself and the options. In case of a mismatch a message is shown indicating that the player should have a look at the help page by executing command -h

Only a few commands need to be adjusted. This is already done in this PR.