### PR TITLE
UI on texture

### DIFF
--- a/addons/armaos/XEH_PREP.hpp
+++ b/addons/armaos/XEH_PREP.hpp
@@ -115,3 +115,9 @@ PREP(terminal_switchTerminalDesign);
 PREP(terminal_setCommandLineByHistory);
 PREP(terminal_setInputMode);
 PREP(terminal_updateBatteryStatus);
+
+PREP(terminal_uiOnTex_init);
+PREP(terminal_uiOnTex_updateOutput);
+PREP(terminal_uiOnTex_updateBatteryStatus);
+PREP(terminal_uiOnTex_setTerminalDesign);
+PREP(terminal_uiOnTex_setKeyboardLayout);

--- a/addons/armaos/XEH_PREP.hpp
+++ b/addons/armaos/XEH_PREP.hpp
@@ -121,3 +121,4 @@ PREP(terminal_uiOnTex_updateOutput);
 PREP(terminal_uiOnTex_updateBatteryStatus);
 PREP(terminal_uiOnTex_setTerminalDesign);
 PREP(terminal_uiOnTex_setKeyboardLayout);
+PREP(terminal_uiOnTex_addUpdateAllEventHandler);

--- a/addons/armaos/XEH_PREP.hpp
+++ b/addons/armaos/XEH_PREP.hpp
@@ -117,6 +117,7 @@ PREP(terminal_setInputMode);
 PREP(terminal_updateBatteryStatus);
 
 PREP(terminal_uiOnTex_init);
+PREP(terminal_uiOnTex_updateAll);
 PREP(terminal_uiOnTex_updateOutput);
 PREP(terminal_uiOnTex_updateBatteryStatus);
 PREP(terminal_uiOnTex_setTerminalDesign);

--- a/addons/armaos/XEH_preInit.sqf
+++ b/addons/armaos/XEH_preInit.sqf
@@ -66,3 +66,18 @@
 ] call CBA_fnc_addSetting;
 
 /* ================================================================================ */
+
+[
+	"AE3_UiOnTexture",
+	"CHECKBOX",
+	["STR_AE3_Main_CbaSettings_UiOnTextureName", "STR_AE3_Main_CbaSettings_UiOnTextureTooltip"],
+	"STR_AE3_ArmaOS_CbaSettings_ArmaOSCategoryName",
+	false,
+    nil, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {  
+        params ["_value"];
+    }, // function that will be executed once on mission start and every time the setting is changed.
+    false // Setting will be marked as needing mission restart after being changed. (optional, default false) <BOOL>
+] call CBA_fnc_addSetting;
+
+/* ================================================================================ */

--- a/addons/armaos/functions/fnc_os_shutdown.sqf
+++ b/addons/armaos/functions/fnc_os_shutdown.sqf
@@ -29,3 +29,9 @@ _computer setVariable ["AE3_computer_mutex", objNull, true];
 closeDialog 1;
 
 private _handle = [_computer, [false]] call (_computer getVariable "AE3_power_fnc_turnOffWrapper");
+
+/* ------------- UI on Texture ------------ */
+
+_computer setVariable ["AE3_UiOnTexActive", false, true]; // reset var for all clients
+
+/* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_os_standby.sqf
+++ b/addons/armaos/functions/fnc_os_standby.sqf
@@ -29,3 +29,9 @@ _computer setVariable ["AE3_computer_mutex", objNull, true];
 closeDialog 1;
 
 private _handle = [_computer] spawn (_computer getVariable "AE3_power_fnc_standbyWrapper");
+
+/* ------------- UI on Texture ------------ */
+
+_computer setVariable ["AE3_UiOnTexActive", false, true]; // reset var for all clients
+
+/* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_addEventHandler.sqf
+++ b/addons/armaos/functions/fnc_terminal_addEventHandler.sqf
@@ -218,7 +218,7 @@ private _result = _consoleDialog displayAddEventHandler
 		/* ------------- UI on Texture ------------ */
 
 		_handleUpdateUiOnTexture = _display getVariable "AE3_handleUpdateUiOnTexture";
-		[_handleUpdateBatteryStatus] call CBA_fnc_removePerFrameHandler;
+		[_handleUpdateUiOnTexture] call CBA_fnc_removePerFrameHandler;
 
 		/* ---------------------------------------- */
 

--- a/addons/armaos/functions/fnc_terminal_addEventHandler.sqf
+++ b/addons/armaos/functions/fnc_terminal_addEventHandler.sqf
@@ -214,6 +214,14 @@ private _result = _consoleDialog displayAddEventHandler
 		_handleUpdateBatteryStatus = _display getVariable "AE3_handleUpdateBatteryStatus";
 		[_handleUpdateBatteryStatus] call CBA_fnc_removePerFrameHandler;
 
+		
+		/* ------------- UI on Texture ------------ */
+
+		_handleUpdateUiOnTexture = _display getVariable "AE3_handleUpdateUiOnTexture";
+		[_handleUpdateBatteryStatus] call CBA_fnc_removePerFrameHandler;
+
+		/* ---------------------------------------- */
+
 		// Updates terminal variable for all
 		_terminal = _computer getVariable "AE3_terminal";
 		_computer setVariable ["AE3_terminal", _terminal, 2];

--- a/addons/armaos/functions/fnc_terminal_init.sqf
+++ b/addons/armaos/functions/fnc_terminal_init.sqf
@@ -23,24 +23,6 @@ private _consoleOutput = _consoleDialog displayCtrl 1100;
 private _languageButton = _consoleDialog displayCtrl 1310;
 private _designButton = _consoleDialog displayCtrl 1320;
 
-/* ------------- UI on Texture ------------ */
-
-private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
-
-{
-   [_computer] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_init", _x];
-} forEach _playersInRange;
-
-/* ---------------------------------------- */
-
-/*
-private _handle = [_computer] spawn AE3_power_fnc_showBatteryLevel;
-
-private _ip = _computer getVariable ["AE3_ipAddress", "127.0.0.1"];
-
-_consoleInput setVariable ["ip", _ip];
-*/
-
 [_computer, "AE3_filesystem"] call AE3_main_fnc_getRemoteVar;
 [_computer, "AE3_filepointer"] call AE3_main_fnc_getRemoteVar;
 

--- a/addons/armaos/functions/fnc_terminal_init.sqf
+++ b/addons/armaos/functions/fnc_terminal_init.sqf
@@ -23,6 +23,16 @@ private _consoleOutput = _consoleDialog displayCtrl 1100;
 private _languageButton = _consoleDialog displayCtrl 1310;
 private _designButton = _consoleDialog displayCtrl 1320;
 
+/* ------------- UI on Texture ------------ */
+
+private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+{
+   [_computer] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_init", _x];
+} forEach _playersInRange;
+
+/* ---------------------------------------- */
+
 /*
 private _handle = [_computer] spawn AE3_power_fnc_showBatteryLevel;
 

--- a/addons/armaos/functions/fnc_terminal_init.sqf
+++ b/addons/armaos/functions/fnc_terminal_init.sqf
@@ -143,6 +143,13 @@ private _currentDesign = _designs select _currentDesignIndex;
 private _handleUpdateBatteryStatus = [_computer, _consoleDialog] call AE3_armaos_fnc_terminal_updateBatteryStatus;
 _consoleDialog setVariable ["AE3_handleUpdateBatteryStatus", _handleUpdateBatteryStatus];
 
+/* ------------- UI on Texture ------------ */
+
+private _handleUpdateUiOnTexture = [_computer, _consoleDialog] call AE3_armaos_fnc_terminal_uiOnTex_addUpdateAllEventHandler;
+_consoleDialog setVariable ["AE3_handleUpdateUiOnTexture", _handleUpdateUiOnTexture];
+
+/* ---------------------------------------- */
+
 [_consoleDialog, _consoleOutput, _languageButton, _designButton] call AE3_armaos_fnc_terminal_addEventHandler;
 
 _terminalBuffer = _terminal get "AE3_terminalBuffer";

--- a/addons/armaos/functions/fnc_terminal_setKeyboardLayout.sqf
+++ b/addons/armaos/functions/fnc_terminal_setKeyboardLayout.sqf
@@ -30,10 +30,13 @@ _computer setVariable ["AE3_terminal", _terminal];
 
 /* ------------- UI on Texture ------------ */
 
-private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
-
+if (AE3_UiOnTexture) then
 {
-   [_computer, _terminalKeyboardLayout] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setKeyboardLayout", _x];
-} forEach _playersInRange;
+	private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+	{
+	[_computer, _terminalKeyboardLayout] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setKeyboardLayout", _x];
+	} forEach _playersInRange;
+};
 
 /* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_setKeyboardLayout.sqf
+++ b/addons/armaos/functions/fnc_terminal_setKeyboardLayout.sqf
@@ -27,3 +27,13 @@ else
 };
 
 _computer setVariable ["AE3_terminal", _terminal];
+
+/* ------------- UI on Texture ------------ */
+
+private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+{
+   [_computer, _terminalKeyboardLayout] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setKeyboardLayout", _x];
+} forEach _playersInRange;
+
+/* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_setKeyboardLayout.sqf
+++ b/addons/armaos/functions/fnc_terminal_setKeyboardLayout.sqf
@@ -34,9 +34,7 @@ if (AE3_UiOnTexture) then
 {
 	private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
 
-	{
-	[_computer, _terminalKeyboardLayout] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setKeyboardLayout", _x];
-	} forEach _playersInRange;
+	[_computer, _terminalKeyboardLayout] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setKeyboardLayout", _playersInRange];
 };
 
 /* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_setTerminalDesign.sqf
+++ b/addons/armaos/functions/fnc_terminal_setTerminalDesign.sqf
@@ -45,12 +45,15 @@ ctrlSetFocus _consoleOutput;
 
 /* ------------- UI on Texture ------------ */
 
-private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
-
-private _computer = _consoleOutput getVariable "AE3_computer";
-
+if (AE3_UiOnTexture) then
 {
-   [_computer, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setTerminalDesign", _x];
-} forEach _playersInRange;
+   private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+   private _computer = _consoleOutput getVariable "AE3_computer";
+
+   {
+      [_computer, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setTerminalDesign", _x];
+   } forEach _playersInRange;
+};
 
 /* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_setTerminalDesign.sqf
+++ b/addons/armaos/functions/fnc_terminal_setTerminalDesign.sqf
@@ -42,3 +42,15 @@ private _consoleOutput = _consoleDialog displayCtrl 1100;
 
 // set focus to text field, otherwise focus stays on button and prohibits additional text input
 ctrlSetFocus _consoleOutput;
+
+/* ------------- UI on Texture ------------ */
+
+private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+private _computer = _consoleOutput getVariable "AE3_computer";
+
+{
+   [_computer, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setTerminalDesign", _x];
+} forEach _playersInRange;
+
+/* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_setTerminalDesign.sqf
+++ b/addons/armaos/functions/fnc_terminal_setTerminalDesign.sqf
@@ -51,9 +51,7 @@ if (AE3_UiOnTexture) then
 
    private _computer = _consoleOutput getVariable "AE3_computer";
 
-   {
-      [_computer, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setTerminalDesign", _x];
-   } forEach _playersInRange;
+   [_computer, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_setTerminalDesign", _playersInRange];
 };
 
 /* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
@@ -1,0 +1,36 @@
+/**
+ * Updates the Battery Symbol in the upper right corner of the terminal application according to the battery status every 15 seconds.
+ *
+ * Arguments:
+ * 1: Computer <OBJECT>
+ * 2: Console Dialog <OBJECT>
+ *
+ * Results:
+ * 1: Per Frame Handler <HANDLE>
+ */
+
+params ["_computer", "_consoleDialog"];
+
+_handle = 
+    [
+        {
+            (_this select 0) params ["_computer", "_consoleDialog"];
+
+            private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+            // get values
+            _outputControl ctrlSetStructuredText (composeText _output);
+
+            private _consoleCtrl = _consoleDialog displayCtrl 1100;
+            private _languageButtonCtrl = _consoleDialog displayCtrl 1310;
+            private _batteryButtonCtrl = _consoleDialog displayCtrl 1050;
+
+            {
+                [_computer, _output] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateAll", _x];
+            } forEach _playersInRange;
+        }, 
+        5, 
+        [_computer, _consoleDialog]
+    ] call CBA_fnc_addPerFrameHandler;
+
+_handle;

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
@@ -42,9 +42,7 @@ _handle =
                 private _terminalBufferVisable = _terminal get "AE3_terminalBufferVisable";
                 private _size = _terminal get "AE3_terminalSize";
 
-                {
-                    [_computer, _terminalBufferVisable, _size, _terminalKeyboardLayout, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateAll", _x];
-                } forEach _playersInRange;
+                [_computer, _terminalBufferVisable, _size, _terminalKeyboardLayout, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateAll", _playersInRange];
             };
         }, 
         _updateInterval, 

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
@@ -37,8 +37,13 @@ _handle =
                 private _fontColorHeader = ctrlTextColor _headerCtrl;
                 private _fontColorConsole = ctrlTextColor _consoleCtrl;
 
+                private _terminal = _computer getVariable "AE3_terminal";
+
+                private _terminalBufferVisable = _terminal get "AE3_terminalBufferVisable";
+                private _size = _terminal get "AE3_terminalSize";
+
                 {
-                    [_computer, _output, _terminalKeyboardLayout, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateAll", _x];
+                    [_computer, _terminalBufferVisable, _size, _terminalKeyboardLayout, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateAll", _x];
                 } forEach _playersInRange;
             };
         }, 

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
@@ -1,3 +1,14 @@
+/**
+ * Adds an 5 Sec Per-Frame-Event-Handler for the "UI on texture" feature. This will update all contents regularly.
+ *
+ * Arguments:
+ * 1: Computer <OBJECT>
+ * 2: Console <DIALOG>
+ *
+ * Results:
+ * None
+ */
+
 params ["_computer", "_consoleDialog"];
 
 private _updateInterval = 5;

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
@@ -1,15 +1,6 @@
-/**
- * Updates the Battery Symbol in the upper right corner of the terminal application according to the battery status every 15 seconds.
- *
- * Arguments:
- * 1: Computer <OBJECT>
- * 2: Console Dialog <OBJECT>
- *
- * Results:
- * 1: Per Frame Handler <HANDLE>
- */
-
 params ["_computer", "_consoleDialog"];
+
+private _updateInterval = 5;
 
 _handle = 
     [
@@ -18,18 +9,26 @@ _handle =
 
             private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
 
-            // get values
-            _outputControl ctrlSetStructuredText (composeText _output);
-
-            private _consoleCtrl = _consoleDialog displayCtrl 1100;
             private _languageButtonCtrl = _consoleDialog displayCtrl 1310;
             private _batteryButtonCtrl = _consoleDialog displayCtrl 1050;
+            private _headerBackgroundCtrl = _consoleDialog displayCtrl 900;
+            private _consoleBackgroundCtrl = _consoleDialog displayCtrl 910;
+            private _headerCtrl = _consoleDialog displayCtrl 1000;
+            private _consoleCtrl = _consoleDialog displayCtrl 1100;
+
+            private _output = ctrlText _consoleCtrl;
+            private _terminalKeyboardLayout = ctrlText _languageButtonCtrl;
+            private _value = ctrlText _batteryButtonCtrl;
+            private _bgColorHeader = ctrlBackgroundColor _headerBackgroundCtrl;
+            private _bgColorConsole = ctrlBackgroundColor _consoleBackgroundCtrl;
+            private _fontColorHeader = ctrlTextColor _headerCtrl;
+            private _fontColorConsole = ctrlTextColor _consoleCtrl;
 
             {
-                [_computer, _output] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateAll", _x];
+                [_computer, _output, _terminalKeyboardLayout, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateAll", _x];
             } forEach _playersInRange;
         }, 
-        5, 
+        _updateInterval, 
         [_computer, _consoleDialog]
     ] call CBA_fnc_addPerFrameHandler;
 

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_addUpdateAllEventHandler.sqf
@@ -7,26 +7,29 @@ _handle =
         {
             (_this select 0) params ["_computer", "_consoleDialog"];
 
-            private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
-
-            private _languageButtonCtrl = _consoleDialog displayCtrl 1310;
-            private _batteryButtonCtrl = _consoleDialog displayCtrl 1050;
-            private _headerBackgroundCtrl = _consoleDialog displayCtrl 900;
-            private _consoleBackgroundCtrl = _consoleDialog displayCtrl 910;
-            private _headerCtrl = _consoleDialog displayCtrl 1000;
-            private _consoleCtrl = _consoleDialog displayCtrl 1100;
-
-            private _output = ctrlText _consoleCtrl;
-            private _terminalKeyboardLayout = ctrlText _languageButtonCtrl;
-            private _value = ctrlText _batteryButtonCtrl;
-            private _bgColorHeader = ctrlBackgroundColor _headerBackgroundCtrl;
-            private _bgColorConsole = ctrlBackgroundColor _consoleBackgroundCtrl;
-            private _fontColorHeader = ctrlTextColor _headerCtrl;
-            private _fontColorConsole = ctrlTextColor _consoleCtrl;
-
+            if (AE3_UiOnTexture) then
             {
-                [_computer, _output, _terminalKeyboardLayout, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateAll", _x];
-            } forEach _playersInRange;
+                private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+                private _languageButtonCtrl = _consoleDialog displayCtrl 1310;
+                private _batteryButtonCtrl = _consoleDialog displayCtrl 1050;
+                private _headerBackgroundCtrl = _consoleDialog displayCtrl 900;
+                private _consoleBackgroundCtrl = _consoleDialog displayCtrl 910;
+                private _headerCtrl = _consoleDialog displayCtrl 1000;
+                private _consoleCtrl = _consoleDialog displayCtrl 1100;
+
+                private _output = ctrlText _consoleCtrl;
+                private _terminalKeyboardLayout = ctrlText _languageButtonCtrl;
+                private _value = ctrlText _batteryButtonCtrl;
+                private _bgColorHeader = ctrlBackgroundColor _headerBackgroundCtrl;
+                private _bgColorConsole = ctrlBackgroundColor _consoleBackgroundCtrl;
+                private _fontColorHeader = ctrlTextColor _headerCtrl;
+                private _fontColorConsole = ctrlTextColor _consoleCtrl;
+
+                {
+                    [_computer, _output, _terminalKeyboardLayout, _bgColorHeader, _bgColorConsole, _fontColorHeader, _fontColorConsole, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateAll", _x];
+                } forEach _playersInRange;
+            };
         }, 
         _updateInterval, 
         [_computer, _consoleDialog]

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_init.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_init.sqf
@@ -1,0 +1,5 @@
+params ["_computer"];
+
+_computer setObjectTexture [1, "#(rgb,1024,1024,1)ui('AE3_ArmaOS_Main_Dialog','AE3_UiOnTexture')"];
+
+_computer setVariable ["AE3_UiOnTexActive", true]; // local variable on computer object is sufficient

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_init.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_init.sqf
@@ -10,6 +10,20 @@
 
 params ["_computer"];
 
+/* -------------- WORKAROUND -------------- */
+
+// Workaround: We need to preload the UI, so the used images are also preloaded; otherwise the
+// images creates a "Cannot load mipmap" error on first usage with the UI2Texture feature
+// See these tickets:
+// https://feedback.bistudio.com/T171035
+// https://feedback.bistudio.com/T170766
+
+private _tmpDisplay = findDisplay 46 createDisplay "AE3_ArmaOS_Main_Dialog";
+_tmpDisplay closeDisplay 1;
+
+/* ---------------------------------------- */
+
 _computer setObjectTexture [1, "#(rgb,1024,1024,1)ui('AE3_ArmaOS_Main_Dialog','AE3_UiOnTexture')"];
 
 _computer setVariable ["AE3_UiOnTexActive", true]; // local variable on computer object is sufficient
+

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_init.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_init.sqf
@@ -1,3 +1,13 @@
+/**
+ * Initializes the texture on the given object for the "UI on texture" feature. 
+ *
+ * Arguments:
+ * 1: Computer <OBJECT>
+ *
+ * Results:
+ * None
+ */
+
 params ["_computer"];
 
 _computer setObjectTexture [1, "#(rgb,1024,1024,1)ui('AE3_ArmaOS_Main_Dialog','AE3_UiOnTexture')"];

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_setKeyboardLayout.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_setKeyboardLayout.sqf
@@ -1,3 +1,14 @@
+/**
+ * Updates the keyboard layout of the terminal for the "UI on texture" feature. 
+ *
+ * Arguments:
+ * 1: Computer <OBJECT>
+ * 2: Keyboard Layout <STRING>
+ *
+ * Results:
+ * None
+ */
+
 params ["_computer", "_terminalKeyboardLayout"];
 
 private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_setKeyboardLayout.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_setKeyboardLayout.sqf
@@ -1,0 +1,15 @@
+params ["_computer", "_terminalKeyboardLayout"];
+
+private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient
+
+if (!_uiOnTexActive) then { [_computer] spawn AE3_armaos_fnc_terminal_uiOnTex_init; };
+
+waitUntil { !isNull findDisplay "AE3_UiOnTexture" };
+
+private _uiOnTextureDisplay = findDisplay "AE3_UiOnTexture";
+
+private _uiOnTextureLanguageCtrl = _uiOnTextureDisplay displayCtrl 1310; // Language Control
+
+_uiOnTextureLanguageCtrl ctrlSetText _terminalKeyboardLayout;
+
+displayUpdate _uiOnTextureDisplay;

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_setTerminalDesign.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_setTerminalDesign.sqf
@@ -1,0 +1,33 @@
+params ["_computer", "_bgColorHeader", "_bgColorConsole", "_fontColorHeader", "_fontColorConsole"];
+
+private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient
+
+if (!_uiOnTexActive) then { [_computer] spawn AE3_armaos_fnc_terminal_uiOnTex_init; };
+
+waitUntil { !isNull findDisplay "AE3_UiOnTexture" };
+
+private _uiOnTextureDisplay = findDisplay "AE3_UiOnTexture";
+
+private _uiOnTextureHeaderBackgroundCtrl = _uiOnTextureDisplay displayCtrl 900;
+private _uiOnTextureConsoleBackgroundCtrl = _uiOnTextureDisplay displayCtrl 910;
+
+private _uiOnTextureHeaderCtrl = _uiOnTextureDisplay displayCtrl 1000;
+private _uiOnTextureConsoleCtrl = _uiOnTextureDisplay displayCtrl 1100;
+
+private _uiOnTextureLanguageButtonCtrl = _uiOnTextureDisplay displayCtrl 1310;
+private _uiOnTextureDesignButtonCtrl = _uiOnTextureDisplay displayCtrl 1320;
+private _uiOnTextureBatteryButtonCtrl = _uiOnTextureDisplay displayCtrl 1050;
+private _uiOnTextureCloseButtonCtrl = _uiOnTextureDisplay displayCtrl 1300;
+
+_uiOnTextureHeaderBackgroundCtrl ctrlSetBackgroundColor _bgColorHeader;
+_uiOnTextureConsoleBackgroundCtrl ctrlSetBackgroundColor _bgColorConsole;
+
+_uiOnTextureHeaderCtrl ctrlSetTextColor _fontColorHeader;
+_uiOnTextureLanguageButtonCtrl ctrlSetTextColor _fontColorHeader;
+_uiOnTextureDesignButtonCtrl ctrlSetTextColor _fontColorHeader;
+_uiOnTextureBatteryButtonCtrl ctrlSetTextColor _fontColorHeader;
+_uiOnTextureCloseButtonCtrl ctrlSetTextColor _fontColorHeader;
+
+_uiOnTextureConsoleCtrl ctrlSetTextColor _fontColorConsole;
+
+displayUpdate _uiOnTextureDisplay;

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_setTerminalDesign.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_setTerminalDesign.sqf
@@ -1,3 +1,17 @@
+/**
+ * Updates the design of the terminal for the "UI on texture" feature. 
+ *
+ * Arguments:
+ * 1: Computer <OBJECT>
+ * 2: Background Color Header <COLOR>
+ * 3: Background Color Console <COLOR>
+ * 4: Font Color Header <COLOR>
+ * 5: Font Color Console <COLOR>
+ *
+ * Results:
+ * None
+ */
+
 params ["_computer", "_bgColorHeader", "_bgColorConsole", "_fontColorHeader", "_fontColorConsole"];
 
 private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
@@ -40,4 +40,16 @@ _uiOnTextureBatteryCtrl ctrlSetText _value;
 
 /* ---------------------------------------- */
 
+private _uiOnTextureOutputCtrl = _uiOnTextureDisplay displayCtrl 1100; // Console Output Control
+
+_uiOnTextureOutputCtrl ctrlSetStructuredText _output;
+
+/* ---------------------------------------- */
+
+private _uiOnTextureLanguageCtrl = _uiOnTextureDisplay displayCtrl 1310; // Language Control
+
+_uiOnTextureLanguageCtrl ctrlSetText _terminalKeyboardLayout;
+
+/* ---------------------------------------- */
+
 displayUpdate _uiOnTextureDisplay;

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
@@ -1,0 +1,43 @@
+params ["_computer", "_output", "_terminalKeyboardLayout", "_bgColorHeader", "_bgColorConsole", "_fontColorHeader", "_fontColorConsole", "_value"];
+
+private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient
+
+if (!_uiOnTexActive) then { [_computer] spawn AE3_armaos_fnc_terminal_uiOnTex_init; };
+
+waitUntil { !isNull findDisplay "AE3_UiOnTexture" };
+
+private _uiOnTextureDisplay = findDisplay "AE3_UiOnTexture";
+
+/* ---------------------------------------- */
+
+private _uiOnTextureHeaderBackgroundCtrl = _uiOnTextureDisplay displayCtrl 900;
+private _uiOnTextureConsoleBackgroundCtrl = _uiOnTextureDisplay displayCtrl 910;
+
+private _uiOnTextureHeaderCtrl = _uiOnTextureDisplay displayCtrl 1000;
+private _uiOnTextureConsoleCtrl = _uiOnTextureDisplay displayCtrl 1100;
+
+private _uiOnTextureLanguageButtonCtrl = _uiOnTextureDisplay displayCtrl 1310;
+private _uiOnTextureDesignButtonCtrl = _uiOnTextureDisplay displayCtrl 1320;
+private _uiOnTextureBatteryButtonCtrl = _uiOnTextureDisplay displayCtrl 1050;
+private _uiOnTextureCloseButtonCtrl = _uiOnTextureDisplay displayCtrl 1300;
+
+_uiOnTextureHeaderBackgroundCtrl ctrlSetBackgroundColor _bgColorHeader;
+_uiOnTextureConsoleBackgroundCtrl ctrlSetBackgroundColor _bgColorConsole;
+
+_uiOnTextureHeaderCtrl ctrlSetTextColor _fontColorHeader;
+_uiOnTextureLanguageButtonCtrl ctrlSetTextColor _fontColorHeader;
+_uiOnTextureDesignButtonCtrl ctrlSetTextColor _fontColorHeader;
+_uiOnTextureBatteryButtonCtrl ctrlSetTextColor _fontColorHeader;
+_uiOnTextureCloseButtonCtrl ctrlSetTextColor _fontColorHeader;
+
+_uiOnTextureConsoleCtrl ctrlSetTextColor _fontColorConsole;
+
+/* ---------------------------------------- */
+
+private _uiOnTextureBatteryCtrl = _uiOnTextureDisplay displayCtrl 1050; // Battery Control
+
+_uiOnTextureBatteryCtrl ctrlSetText _value;
+
+/* ---------------------------------------- */
+
+displayUpdate _uiOnTextureDisplay;

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
@@ -1,3 +1,21 @@
+/**
+ * Updates all content of the terminal for the "UI on texture" feature. 
+ *
+ * Arguments:
+ * 1: Computer <OBJECT>
+ * 2: Output <STRUCTURED TEXT>
+ * 3: Keyboard Layout <STRING>
+ * 4: Background Color Header <COLOR>
+ * 5: Background Color Console <COLOR>
+ * 6: Font Color Header <COLOR>
+ * 7: Font Color Console <COLOR>
+ * 8: Battery Symbol Path <STRING>
+ *
+ * Results:
+ * None
+ */
+
+
 params ["_computer", "_output", "_terminalKeyboardLayout", "_bgColorHeader", "_bgColorConsole", "_fontColorHeader", "_fontColorConsole", "_value"];
 
 private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
@@ -60,7 +60,24 @@ _uiOnTextureBatteryCtrl ctrlSetText _value;
 
 private _uiOnTextureOutputCtrl = _uiOnTextureDisplay displayCtrl 1100; // Console Output Control
 
-_uiOnTextureOutputCtrl ctrlSetStructuredText _output;
+// We need to compose the text again because we can't read the structuredText from the existing control,
+// like we do on the other controls. StructuredText is set-only.
+
+private _terminal = _computer getVariable "AE3_terminal";
+
+private _terminalBuffer = _terminal get "AE3_terminalBuffer";
+private _terminalBufferVisable = _terminal get "AE3_terminalBufferVisable";
+private _size = _terminal get "AE3_terminalSize";
+
+private _output = [];
+{
+	_buffer = composeText [_x, lineBreak];
+	_buffer setAttributes ["size", str _size, "font", "EtelkaMonospacePro"];
+	_output pushBack _buffer;
+} forEach _terminalBufferVisable;
+
+_uiOnTextureOutputCtrl ctrlSetStructuredText (composeText _output);
+
 
 /* ---------------------------------------- */
 

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_updateAll.sqf
@@ -3,20 +3,21 @@
  *
  * Arguments:
  * 1: Computer <OBJECT>
- * 2: Output <STRUCTURED TEXT>
- * 3: Keyboard Layout <STRING>
- * 4: Background Color Header <COLOR>
- * 5: Background Color Console <COLOR>
- * 6: Font Color Header <COLOR>
- * 7: Font Color Console <COLOR>
- * 8: Battery Symbol Path <STRING>
+ * 2: Terminal Buffer Visable <ARRAY>
+ * 3: Size <NUMBER>
+ * 4: Keyboard Layout <STRING>
+ * 5: Background Color Header <COLOR>
+ * 6: Background Color Console <COLOR>
+ * 7: Font Color Header <COLOR>
+ * 8: Font Color Console <COLOR>
+ * 9: Battery Symbol Path <STRING>
  *
  * Results:
  * None
  */
 
 
-params ["_computer", "_output", "_terminalKeyboardLayout", "_bgColorHeader", "_bgColorConsole", "_fontColorHeader", "_fontColorConsole", "_value"];
+params ["_computer", "_terminalBufferVisable", "_size", "_terminalKeyboardLayout", "_bgColorHeader", "_bgColorConsole", "_fontColorHeader", "_fontColorConsole", "_value"];
 
 private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient
 
@@ -63,15 +64,9 @@ private _uiOnTextureOutputCtrl = _uiOnTextureDisplay displayCtrl 1100; // Consol
 // We need to compose the text again because we can't read the structuredText from the existing control,
 // like we do on the other controls. StructuredText is set-only.
 
-private _terminal = _computer getVariable "AE3_terminal";
-
-private _terminalBuffer = _terminal get "AE3_terminalBuffer";
-private _terminalBufferVisable = _terminal get "AE3_terminalBufferVisable";
-private _size = _terminal get "AE3_terminalSize";
-
 private _output = [];
 {
-	_buffer = composeText [_x, lineBreak];
+	private _buffer = composeText [_x, lineBreak];
 	_buffer setAttributes ["size", str _size, "font", "EtelkaMonospacePro"];
 	_output pushBack _buffer;
 } forEach _terminalBufferVisable;

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_updateBatteryStatus.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_updateBatteryStatus.sqf
@@ -1,0 +1,15 @@
+params ["_computer", "_value"];
+
+private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient
+
+if (!_uiOnTexActive) then { [_computer] spawn AE3_armaos_fnc_terminal_uiOnTex_init; };
+
+waitUntil { !isNull findDisplay "AE3_UiOnTexture" };
+
+private _uiOnTextureDisplay = findDisplay "AE3_UiOnTexture";
+
+private _uiOnTextureBatteryCtrl = _uiOnTextureDisplay displayCtrl 1050; // Battery Control
+
+_uiOnTextureBatteryCtrl ctrlSetText format ["\z\ae3\addons\armaos\images\AE3_battery_%1_percent.paa", _value];
+
+displayUpdate _uiOnTextureDisplay;

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_updateBatteryStatus.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_updateBatteryStatus.sqf
@@ -1,3 +1,14 @@
+/**
+ * Updates the battery symbol of the terminal for the "UI on texture" feature. 
+ *
+ * Arguments:
+ * 1: Computer <OBJECT>
+ * 2: Battery Symbol Path <STRING>
+ *
+ * Results:
+ * None
+ */
+
 params ["_computer", "_value"];
 
 private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_updateOutput.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_updateOutput.sqf
@@ -1,0 +1,15 @@
+params ["_computer", "_output"];
+
+private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient
+
+if (!_uiOnTexActive) then { [_computer] spawn AE3_armaos_fnc_terminal_uiOnTex_init; };
+
+waitUntil { !isNull findDisplay "AE3_UiOnTexture" };
+
+private _uiOnTextureDisplay = findDisplay "AE3_UiOnTexture";
+
+private _uiOnTextureOutputCtrl = _uiOnTextureDisplay displayCtrl 1100; // Console Output Control
+
+_uiOnTextureOutputCtrl ctrlSetStructuredText (composeText _output);
+
+displayUpdate _uiOnTextureDisplay;

--- a/addons/armaos/functions/fnc_terminal_uiOnTex_updateOutput.sqf
+++ b/addons/armaos/functions/fnc_terminal_uiOnTex_updateOutput.sqf
@@ -1,3 +1,14 @@
+/**
+ * Updates terminal output for the "UI on texture" feature. 
+ *
+ * Arguments:
+ * 1: Computer <OBJECT>
+ * 2: Output <STRUCTURED TEXT>
+ *
+ * Results:
+ * None
+ */
+
 params ["_computer", "_output"];
 
 private _uiOnTexActive = _computer getVariable ["AE3_UiOnTexActive", false]; // local variable on computer object is sufficient

--- a/addons/armaos/functions/fnc_terminal_updateBatteryStatus.sqf
+++ b/addons/armaos/functions/fnc_terminal_updateBatteryStatus.sqf
@@ -47,11 +47,14 @@ _handle =
                     _value = (floor (_batteryLevelPercent / 25)) * 25;
                 };
 
-                _batteryCtrl ctrlSetText format ["\z\ae3\addons\armaos\images\AE3_battery_%1_percent.paa", _value];
+                private _oldValue = ctrlText _batteryCtrl;
+    	        private _newValue = format ["\z\ae3\addons\armaos\images\AE3_battery_%1_percent.paa", _value];
+
+                _batteryCtrl ctrlSetText _newValue;
 
                 /* ------------- UI on Texture ------------ */
 
-                if (AE3_UiOnTexture) then
+                if ((AE3_UiOnTexture) && !(_oldValue isEqualTo _newValue)) then
                 {
                     private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
 

--- a/addons/armaos/functions/fnc_terminal_updateBatteryStatus.sqf
+++ b/addons/armaos/functions/fnc_terminal_updateBatteryStatus.sqf
@@ -55,9 +55,7 @@ _handle =
                 {
                     private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
 
-                    {
-                        [_computer, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateBatteryStatus", _x];
-                    } forEach _playersInRange;
+                    [_computer, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateBatteryStatus", _playersInRange];
                 };
 
                 /* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_updateBatteryStatus.sqf
+++ b/addons/armaos/functions/fnc_terminal_updateBatteryStatus.sqf
@@ -23,14 +23,14 @@ uiNamespace setVariable ["AE3_ConsoleOutput", _outputCtrl];
 _handle = 
     [
         {
-            (_this select 0) params ["_battery", "_batteryCtrl"];
+            (_this select 0) params ["_computer", "_battery", "_batteryCtrl"];
 
             // We have to use 'spawn' inside 'perFrameEventHandler' because this is a scheduled environment, 
             // but 'getRemoteVar' in 'getBatteryLevel' needs unscheduled environment to work properly.
             // Otherwise throwing "suspending not allowd in this context" error.
-            [_battery, _batteryCtrl] spawn 
+            [_computer, _battery, _batteryCtrl] spawn 
             {
-                params ["_battery", "_batteryCtrl"];
+                params ["_computer", "_battery", "_batteryCtrl"];
 
                 private _params = [_battery] call AE3_power_fnc_getBatteryLevel;
 
@@ -48,10 +48,20 @@ _handle =
                 };
 
                 _batteryCtrl ctrlSetText format ["\z\ae3\addons\armaos\images\AE3_battery_%1_percent.paa", _value];
+
+                /* ------------- UI on Texture ------------ */
+
+                private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+                {
+                    [_computer, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateBatteryStatus", _x];
+                } forEach _playersInRange;
+
+                /* ---------------------------------------- */
             };
         }, 
         60, 
-        [_battery, _batteryCtrl]
+        [_computer, _battery, _batteryCtrl]
     ] call CBA_fnc_addPerFrameHandler;
 
 _handle;

--- a/addons/armaos/functions/fnc_terminal_updateBatteryStatus.sqf
+++ b/addons/armaos/functions/fnc_terminal_updateBatteryStatus.sqf
@@ -51,11 +51,14 @@ _handle =
 
                 /* ------------- UI on Texture ------------ */
 
-                private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
-
+                if (AE3_UiOnTexture) then
                 {
-                    [_computer, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateBatteryStatus", _x];
-                } forEach _playersInRange;
+                    private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+                    {
+                        [_computer, _value] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateBatteryStatus", _x];
+                    } forEach _playersInRange;
+                };
 
                 /* ---------------------------------------- */
             };

--- a/addons/armaos/functions/fnc_terminal_updateOutput.sqf
+++ b/addons/armaos/functions/fnc_terminal_updateOutput.sqf
@@ -37,9 +37,7 @@ if (AE3_UiOnTexture) then
 {
 	private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
 
-	{
-		[_computer, _output] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateOutput", _x];
-	} forEach _playersInRange;
+	[_computer, _output] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateOutput", _playersInRange];
 };
 
 /* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_updateOutput.sqf
+++ b/addons/armaos/functions/fnc_terminal_updateOutput.sqf
@@ -30,3 +30,13 @@ _outputControl ctrlSetStructuredText (composeText _output);
 ctrlSetFocus _outputControl;
 
 _computer setVariable ["AE3_terminal", _terminal];
+
+/* ------------- UI on Texture ------------ */
+
+private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+{
+	[_computer, _output] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateOutput", _x];
+} forEach _playersInRange;
+
+/* ---------------------------------------- */

--- a/addons/armaos/functions/fnc_terminal_updateOutput.sqf
+++ b/addons/armaos/functions/fnc_terminal_updateOutput.sqf
@@ -33,10 +33,13 @@ _computer setVariable ["AE3_terminal", _terminal];
 
 /* ------------- UI on Texture ------------ */
 
-private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
-
+if (AE3_UiOnTexture) then
 {
-	[_computer, _output] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateOutput", _x];
-} forEach _playersInRange;
+	private _playersInRange = [3, _computer] call AE3_main_fnc_getPlayersInRange;
+
+	{
+		[_computer, _output] remoteExec ["AE3_armaos_fnc_terminal_uiOnTex_updateOutput", _x];
+	} forEach _playersInRange;
+};
 
 /* ---------------------------------------- */

--- a/addons/armaos/stringtable.xml
+++ b/addons/armaos/stringtable.xml
@@ -1324,6 +1324,24 @@
                 <French>Détermine la vitesse en lignes de la fonction de défilement de la molette de la souris pour le terminal.</French>
                 <Italian>Determina la velocità in linee per la funzionalità di scroll della rotellina del mouse.</Italian>
             </Key>
+            <Key ID="STR_AE3_Main_CbaSettings_UiOnTextureName">
+                <Original>UI on texture</Original>
+                <English>UI on texture</English>
+                <German>UI auf Textur</German>
+                <Chinesesimp>UI on texture</Chinesesimp>
+                <Russian>UI on texture</Russian>
+                <French>UI on texture</French>
+                <Italian>UI on texture</Italian>
+            </Key>
+            <Key ID="STR_AE3_Main_CbaSettings_UiOnTextureTooltip">
+                <Original>If enabled, surrounding players can see the armaOS interface on the computers texture.</Original>
+                <English>If enabled, surrounding players can see the armaOS interface on the computers texture.</English>
+                <German>Wenn aktiviert, können Spieler in der Nähe das armaOS Interface auf der Textur des Computers sehen.</German>
+                <Chinesesimp>If enabled, surrounding players can see the armaOS interface on the computers texture.</Chinesesimp>
+                <Russian>If enabled, surrounding players can see the armaOS interface on the computers texture.</Russian>
+                <French>If enabled, surrounding players can see the armaOS interface on the computers texture.</French>
+                <Italian>If enabled, surrounding players can see the armaOS interface on the computers texture.</Italian>
+            </Key>
             <Key ID="STR_AE3_Main_CbaSettings_1line">
                 <Original>1 line</Original>
                 <English>1 line</English>

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -16,3 +16,6 @@ PREP(3den_checkConnection);
 PREP(3den_doNetworkConnection);
 PREP(3den_doPowerConnection);
 PREP(killDebugOverlay);
+
+// Misc
+PREP(getPlayersInRange);

--- a/addons/main/functions/fnc_getPlayersInRange.sqf
+++ b/addons/main/functions/fnc_getPlayersInRange.sqf
@@ -13,9 +13,6 @@ params ["_range", "_object"];
 
 private _allPlayers = [] call BIS_fnc_listPlayers; // Only players, not headless clients
 
-private _playersInRange = [];
-{
-    if ((_x distance _object) < _range) then { _playersInRange pushBack _x; }; 
-} forEach _allPlayers;
+private _playersInRange = _allPlayers select {_x distance _object) < _range};
 
 _playersInRange;

--- a/addons/main/functions/fnc_getPlayersInRange.sqf
+++ b/addons/main/functions/fnc_getPlayersInRange.sqf
@@ -1,0 +1,10 @@
+params ["_range", "_object"];
+
+private _allPlayers = [] call BIS_fnc_listPlayers; // Only players, not headless clients
+
+private _playersInRange = [];
+{
+    if ((_x distance _object) < _range) then { _playersInRange pushBack _x; }; 
+} forEach _allPlayers;
+
+_playersInRange;

--- a/addons/main/functions/fnc_getPlayersInRange.sqf
+++ b/addons/main/functions/fnc_getPlayersInRange.sqf
@@ -13,6 +13,6 @@ params ["_range", "_object"];
 
 private _allPlayers = [] call BIS_fnc_listPlayers; // Only players, not headless clients
 
-private _playersInRange = _allPlayers select {_x distance _object) < _range};
+private _playersInRange = _allPlayers select {(_x distance _object) < _range};
 
 _playersInRange;

--- a/addons/main/functions/fnc_getPlayersInRange.sqf
+++ b/addons/main/functions/fnc_getPlayersInRange.sqf
@@ -1,3 +1,14 @@
+/**
+ * Returns all players within a radius around the given object.
+ *
+ * Arguments:
+ * 0: Range <NUMBER>
+ * 1: Object <OBJECT>
+ * 
+ * Return:
+ * Nothing
+ */
+
 params ["_range", "_object"];
 
 private _allPlayers = [] call BIS_fnc_listPlayers; // Only players, not headless clients


### PR DESCRIPTION
### Introduction
Merging this pull request will introduce the **UI on texture** feature, which means that the armaOS UI is rendered also on the laptop texture and can be seen by players in a 3m circle around the laptop. 

There are two triggers that force an update on the **UI on texture**. First, every change on the UI, for example text input/output, changing design, changing battery status etc. forces an update on this specific content. Secondly, an event handler updates all aspects of the **UI on texture** every 5 seconds. This should prevent the case, that someone who joins the circle later, does not get the current content of the UI, if the player that uses armaOS does not interact for a while.

A CBA settings controls wether or not a player invokes updates on his surrounding players textures. Can be forced by server.

### Todos
- [x] add CBA setting to enable/disable this feature globally
- [x] add function headers
- [x] BI Bug Report for the know bug
- [ ] ~add support for `snake`~

### Annotations
- All Updates for UI on texture are send via `remoteExec` to all clients in a 3m circle around the laptop. Even the update for the invoking player is done via `remoteExec`. If this is harmless, I wouldn't change that.
- We could modify the code, so that the `updateAll` function does not fire permanently but only if someone is joining the circle. For now I leave it as it is.
- The new local variable `AE3_UiOnTexActive` is used to determine, if a computer-display was already initialized for "UI on texture" on a specific client. 

### Known Bugs
- The first time a client gets an Update, produces an error. I don't know if this is an Arma 3 Bug or something that I could fix, see screenshot. The Bug is reported here: https://feedback.bistudio.com/T171035
![20230310120954_1](https://user-images.githubusercontent.com/50139270/224324113-7700a401-07b2-4aff-b056-0b4be1f3eb91.jpg)
