### PR TITLE
Eden attribute for PowerOn on mission start

### DIFF
--- a/addons/armaos/CfgVehicles.hpp
+++ b/addons/armaos/CfgVehicles.hpp
@@ -27,6 +27,22 @@ class CfgVehicles
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
 			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
 		};
 
 		// Event Handlers
@@ -155,6 +171,22 @@ class CfgVehicles
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
 			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
 		};
 
 		// Event Handlers
@@ -282,6 +314,22 @@ class CfgVehicles
 				validate = "number"; // Validate the value before saving. If the value is not of given type e.g. "number", the default value will be set. Can be "none", "expression", "condition", "number" or "variable"
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
+			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
 			};
 		};
 

--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -5,6 +5,25 @@ class CfgVehicles
 	class Land_PortableLight_single_F;
 	class Land_PortableLight_single_F_AE3: Land_PortableLight_single_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Device
 		{
 			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
@@ -57,6 +76,25 @@ class CfgVehicles
  	class Land_PortableLight_double_F;
 	class Land_PortableLight_double_F_AE3: Land_PortableLight_double_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Device
 		{
 			init = "params['_entity']; [_entity] call AE3_interaction_fnc_initLamp;";
@@ -111,6 +149,25 @@ class CfgVehicles
  	class Land_PortableLight_02_single_yellow_F;
 	class Land_PortableLight_02_single_yellow_F_AE3: Land_PortableLight_02_single_yellow_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -201,6 +258,25 @@ class CfgVehicles
  	class Land_PortableLight_02_single_olive_F;
 	class Land_PortableLight_02_single_olive_F_AE3: Land_PortableLight_02_single_olive_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -291,6 +367,25 @@ class CfgVehicles
  	class Land_PortableLight_02_single_black_F;
 	class Land_PortableLight_02_single_black_F_AE3: Land_PortableLight_02_single_black_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -381,6 +476,25 @@ class CfgVehicles
  	class Land_PortableLight_02_single_sand_F;
 	class Land_PortableLight_02_single_sand_F_AE3: Land_PortableLight_02_single_sand_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -471,6 +585,25 @@ class CfgVehicles
 	class Land_PortableLight_02_double_yellow_F;
 	class Land_PortableLight_02_double_yellow_F_AE3: Land_PortableLight_02_double_yellow_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -594,6 +727,25 @@ class CfgVehicles
 	class Land_PortableLight_02_double_olive_F;
 	class Land_PortableLight_02_double_olive_F_AE3: Land_PortableLight_02_double_olive_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -717,6 +869,25 @@ class CfgVehicles
 	class Land_PortableLight_02_double_black_F;
 	class Land_PortableLight_02_double_black_F_AE3: Land_PortableLight_02_double_black_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -840,6 +1011,25 @@ class CfgVehicles
 	class Land_PortableLight_02_double_sand_F;
 	class Land_PortableLight_02_double_sand_F_AE3: Land_PortableLight_02_double_sand_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -963,6 +1153,25 @@ class CfgVehicles
 	class Land_PortableLight_02_quad_yellow_F;
 	class Land_PortableLight_02_quad_yellow_F_AE3: Land_PortableLight_02_quad_yellow_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -1152,6 +1361,25 @@ class CfgVehicles
 	class Land_PortableLight_02_quad_olive_F;
 	class Land_PortableLight_02_quad_olive_F_AE3: Land_PortableLight_02_quad_olive_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -1341,6 +1569,25 @@ class CfgVehicles
 	class Land_PortableLight_02_quad_black_F;
 	class Land_PortableLight_02_quad_black_F_AE3: Land_PortableLight_02_quad_black_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -1530,6 +1777,25 @@ class CfgVehicles
 	class Land_PortableLight_02_quad_sand_F;
 	class Land_PortableLight_02_quad_sand_F_AE3: Land_PortableLight_02_quad_sand_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_LampDisplayName";
@@ -1719,6 +1985,25 @@ class CfgVehicles
 	class Land_PortableDesk_01_olive_F;
 	class Land_PortableDesk_01_olive_F_AE3: Land_PortableDesk_01_olive_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Equipment
 		{
 			displayName = "$STR_AE3_Interaction_Config_DeskDisplayName";

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -132,6 +132,24 @@
                 <French>Niveau de puissance défini au début de la mission</French>
                 <Italian>Livello potenza elettrica impostata all'inizio della missione</Italian>
             </Key>
+            <Key ID="STR_AE3_Main_EdenAttributes_PowerStateDisplayName">
+                <Original>Power State</Original>
+                <English>Power State</English>
+                <German>Betriebszustand</German>
+                <Chinesesimp>Power State</Chinesesimp>
+                <Russian>Power State</Russian>
+                <French>Power State</French>
+                <Italian>Power State</Italian>
+            </Key>
+            <Key ID="STR_AE3_Main_EdenAttributes_PowerStateTooltip">
+                <Original>Is the device turned on at the beginning of the mission?</Original>
+                <English>Is the device turned on at the beginning of the mission?</English>
+                <German>Ist das Gerät zum Beginn der Mission angeschaltet?</German>
+                <Chinesesimp>Is the device turned on at the beginning of the mission?</Chinesesimp>
+                <Russian>Is the device turned on at the beginning of the mission?</Russian>
+                <French>Is the device turned on at the beginning of the mission?</French>
+                <Italian>Is the device turned on at the beginning of the mission?</Italian>
+            </Key>
             <Key ID="STR_AE3_Main_EdenAttributes_FuelLevelDisplayName">
                 <Original>Fuel Level</Original>
                 <English>Fuel Level</English>

--- a/addons/network/CfgVehicles.hpp
+++ b/addons/network/CfgVehicles.hpp
@@ -6,6 +6,25 @@ class CfgVehicles
 	class Land_Router_01_olive_F;
 	class Land_Router_01_olive_F_AE3: Land_Router_01_olive_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Device
 		{
 			displayName = "$STR_AE3_Network_Config_RouterDisplayName";
@@ -53,6 +72,25 @@ class CfgVehicles
 	class Land_Router_01_black_F;
 	class Land_Router_01_black_F_AE3: Land_Router_01_black_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Device
 		{
 			displayName = "$STR_AE3_Network_Config_RouterDisplayName";
@@ -100,6 +138,25 @@ class CfgVehicles
 	class Land_Router_01_sand_F;
 	class Land_Router_01_sand_F_AE3: Land_Router_01_sand_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Device
 		{
 			displayName = "$STR_AE3_Network_Config_RouterDisplayName";

--- a/addons/power/CfgVehicles.hpp
+++ b/addons/power/CfgVehicles.hpp
@@ -25,6 +25,22 @@ class CfgVehicles
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
 			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
 		};
 
 		// scope = 1; //Hide class in 3DEN asset browser
@@ -153,6 +169,22 @@ class CfgVehicles
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
 			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
 		};
 		
 		// Refuel
@@ -263,6 +295,22 @@ class CfgVehicles
 				validate = "number"; // Validate the value before saving. If the value is not of given type e.g. "number", the default value will be set. Can be "none", "expression", "condition", "number" or "variable"
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
+			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
 			};
 		};
 		
@@ -375,6 +423,22 @@ class CfgVehicles
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
 			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
 		};
 		
 		// Refuel
@@ -485,6 +549,22 @@ class CfgVehicles
 				validate = "number"; // Validate the value before saving. If the value is not of given type e.g. "number", the default value will be set. Can be "none", "expression", "condition", "number" or "variable"
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
+			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
 			};
 		};
 		
@@ -601,6 +681,22 @@ class CfgVehicles
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
 			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
 		};
 
 		class AE3_Device
@@ -671,6 +767,22 @@ class CfgVehicles
 				validate = "number"; // Validate the value before saving. If the value is not of given type e.g. "number", the default value will be set. Can be "none", "expression", "condition", "number" or "variable"
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
+			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
 			};
 		};
     
@@ -743,6 +855,22 @@ class CfgVehicles
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
 			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
 		};
     
 		class AE3_Device
@@ -813,6 +941,22 @@ class CfgVehicles
 				validate = "number"; // Validate the value before saving. If the value is not of given type e.g. "number", the default value will be set. Can be "none", "expression", "condition", "number" or "variable"
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
+			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
 			};
 		};
 
@@ -957,6 +1101,22 @@ class CfgVehicles
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
 			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
 		};
     
 		// Cargo
@@ -1100,6 +1260,22 @@ class CfgVehicles
 				condition = "1"; // Condition for attribute to appear (see the table below)
 				typeName = "NUMBER"; // Defines data type of saved value, can be STRING, NUMBER or BOOL. Used only when control is "Combo", "Edit" or their variants
 			};
+
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
 		};
     
 		class AE3_Equipment
@@ -1218,6 +1394,25 @@ class CfgVehicles
 	class Land_PortableSolarPanel_01_olive_F;
 	class Land_PortableSolarPanel_01_olive_F_AE3 : Land_PortableSolarPanel_01_olive_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Device
 		{
 			displayName = "$STR_AE3_Power_Config_SolarPanelDisplayName";
@@ -1260,6 +1455,25 @@ class CfgVehicles
 	class Land_PortableSolarPanel_01_sand_F;
 	class Land_PortableSolarPanel_01_sand_F_AE3 : Land_PortableSolarPanel_01_sand_F
 	{
+		class Attributes
+		{
+			class AE3_EdenAttribute_PowerState
+			{
+				//--- Mandatory properties
+				displayName = "$STR_AE3_Main_EdenAttributes_PowerStateDisplayName"; // Name assigned to UI control class Title
+				tooltip = "$STR_AE3_Main_EdenAttributes_PowerStateTooltip"; // Tooltip assigned to UI control class Title
+				property = "AE3_EdenAttribute_PowerState"; // Unique config property name saved in SQM
+				control = "CheckBox"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+
+				expression = "_this setVariable ['%s', _value, true];";
+
+				defaultValue = "false";
+
+				//--- Optional properties
+				unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+			};
+		};
+
 		class AE3_Device
 		{
 			displayName = "$STR_AE3_Power_Config_SolarPanelDisplayName";

--- a/addons/power/XEH_PREP.hpp
+++ b/addons/power/XEH_PREP.hpp
@@ -29,6 +29,7 @@ PREP(initGenerator);
 PREP(initFuelLevelWithEdenAttribute);
 PREP(initConsumer);
 PREP(initSolarPanel);
+PREP(initDeviceTurnOn);
 
 /* Sys */
 PREP(batteryCalculation);

--- a/addons/power/functions/fnc_initDevice.sqf
+++ b/addons/power/functions/fnc_initDevice.sqf
@@ -146,3 +146,8 @@ _entity setVariable ["AE3_power_fnc_standbyCondition", _standbyCondition];
 _entity setVariable ["AE3_power_fnc_standbyWrapper", _standbyWrapper];
 
 [_entity] call _initFnc;
+
+if(isServer) then
+{
+	[_entity] call AE3_power_fnc_initDeviceTurnOn;
+};

--- a/addons/power/functions/fnc_initDeviceTurnOn.sqf
+++ b/addons/power/functions/fnc_initDeviceTurnOn.sqf
@@ -1,0 +1,36 @@
+/**
+ * Sets the power state for a given device if value is changed in Eden Editor.
+ *
+ * Arguments:
+ * 0: Device <OBJECT>
+ * 
+ * Returns:
+ * None
+ */
+
+params ["_device"];
+
+[_device] spawn
+{
+    params ["_device"];
+
+    // wait until the eden attribute is set via expression; unset is -1; regular values should be between 0 and 1
+    waitUntil { !(isNil {_device getVariable "AE3_EdenAttribute_PowerState"}) };
+
+    private _edenAttributePowerState = _device getVariable "AE3_EdenAttribute_PowerState";
+
+	if (!_edenAttributePowerState) exitWith {diag_log "AE3: Not set";};
+
+    // wait until all "init" processes are done, see: https://community.bistudio.com/wiki/Initialization_Order
+    waitUntil { !isNil "BIS_fnc_init" };
+
+	private _condition = ((_device call (_device getVariable ["AE3_power_fnc_turnOnCondition", {true}]) and
+							(alive _device) and 
+						(_device getVariable 'AE3_power_powerState' != 1) and 
+						!(_device getVariable ['AE3_power_mutex', false]) and 
+						(_device getVariable ['AE3_interaction_closeState', 0] == 0)));
+	//if (_condition) exitWith {diag_log "AE3: Condition not met";};
+
+	[_device, [true]] call (_device getVariable "AE3_power_fnc_turnOnWrapper");
+	_device setVariable ['AE3_power_mutex', false, true];
+};

--- a/addons/power/functions/fnc_initDeviceTurnOn.sqf
+++ b/addons/power/functions/fnc_initDeviceTurnOn.sqf
@@ -19,7 +19,7 @@ params ["_device"];
 
     private _edenAttributePowerState = _device getVariable "AE3_EdenAttribute_PowerState";
 
-	if (!_edenAttributePowerState) exitWith {diag_log "AE3: Not set";};
+	if (!_edenAttributePowerState) exitWith {};
 
     // wait until all "init" processes are done, see: https://community.bistudio.com/wiki/Initialization_Order
     waitUntil { !isNil "BIS_fnc_init" };
@@ -42,8 +42,8 @@ params ["_device"];
 						!(_device getVariable ['AE3_power_mutex', false]) and 
 						(_device getVariable ['AE3_interaction_closeState', 0] == 0)));
 
-	if (!_condition) exitWith {diag_log "AE3: Condition not met";};
+	if (!_condition) exitWith {};
 
-	[_device, [true]] call (_device getVariable "AE3_power_fnc_turnOnWrapper");
+	[_device, [true]] spawn (_device getVariable "AE3_power_fnc_turnOnWrapper");
 	_device setVariable ['AE3_power_mutex', false, true];
 };

--- a/addons/power/functions/fnc_initDeviceTurnOn.sqf
+++ b/addons/power/functions/fnc_initDeviceTurnOn.sqf
@@ -24,12 +24,25 @@ params ["_device"];
     // wait until all "init" processes are done, see: https://community.bistudio.com/wiki/Initialization_Order
     waitUntil { !isNil "BIS_fnc_init" };
 
+	private _powerCableDevice = _device getVariable "AE3_power_powerCableDevice";
+
+	if (!isNil "_powerCableDevice") then
+	{
+		waitUntil { !(isNil {_powerCableDevice getVariable "AE3_EdenAttribute_PowerState"}) };
+		
+		if (_powerCableDevice getVariable "AE3_EdenAttribute_PowerState") then
+		{
+			waitUntil {_powerCableDevice getVariable "AE3_power_powerState" == 1};
+		};
+	};
+
 	private _condition = ((_device call (_device getVariable ["AE3_power_fnc_turnOnCondition", {true}]) and
 							(alive _device) and 
 						(_device getVariable 'AE3_power_powerState' != 1) and 
 						!(_device getVariable ['AE3_power_mutex', false]) and 
 						(_device getVariable ['AE3_interaction_closeState', 0] == 0)));
-	//if (_condition) exitWith {diag_log "AE3: Condition not met";};
+
+	if (!_condition) exitWith {diag_log "AE3: Condition not met";};
 
 	[_device, [true]] call (_device getVariable "AE3_power_fnc_turnOnWrapper");
 	_device setVariable ['AE3_power_mutex', false, true];

--- a/addons/power/functions/fnc_turnOnGeneratorAction.sqf
+++ b/addons/power/functions/fnc_turnOnGeneratorAction.sqf
@@ -31,11 +31,10 @@ private _result = false;
 if (_fuelLevel > 0) then
 {
 	private _turnOnTime = 5;
+	private _startSoundHandle = [_entity] spawn AE3_power_fnc_playGeneratorStartSound;
+
 
 	if (!_silent) then {
-
-		private _startSoundHandle = [_entity] spawn AE3_power_fnc_playGeneratorStartSound;
-
 		[
 		_turnOnTime,
 		[_entity, _startSoundHandle, _turnOnFnc], 

--- a/addons/power/functions/fnc_turnOnGeneratorAction.sqf
+++ b/addons/power/functions/fnc_turnOnGeneratorAction.sqf
@@ -8,11 +8,23 @@
  * None
  */
 
-params ["_entity"];
+params ["_entity", ["_silent", false]];
 
 private _fuelCapacity = _entity getVariable "AE3_power_fuelCapacity";
 private _fuelLevelPercent = fuel _entity;
 private _fuelLevel = _fuelCapacity * _fuelLevelPercent;
+
+private _turnOnFnc = {
+	params ["_entity"];
+
+	[_entity, AE3_power_fnc_fuelConsumption] remoteExecCall ["AE3_power_fnc_addProviderHandler", 2];
+
+	[_entity, "turnedOn", true] remoteExecCall ["AE3_interaction_fnc_manageAce3Interactions", 2];
+
+	// we need to set power state here because function already returned false
+	// and therefore the turn on wrapper doesn't set the state to turned on
+	_entity setVariable ["AE3_power_powerState", 1, true];
+};
 
 private _result = false;
 
@@ -20,24 +32,20 @@ if (_fuelLevel > 0) then
 {
 	private _turnOnTime = 5;
 
-	private _startSoundHandle = [_entity] spawn AE3_power_fnc_playGeneratorStartSound;
+	if (!_silent) then {
 
-	[
+		private _startSoundHandle = [_entity] spawn AE3_power_fnc_playGeneratorStartSound;
+
+		[
 		_turnOnTime,
-		[_entity, _startSoundHandle], 
+		[_entity, _startSoundHandle, _turnOnFnc], 
 		{
 			// following code only runs on progress bar success
 			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
 			
-			_args params ["_entity", "_startSoundHandle"];
+			_args params ["_entity", "_startSoundHandle", "_turnOnFnc"];
 
-			[_entity, AE3_power_fnc_fuelConsumption] remoteExecCall ["AE3_power_fnc_addProviderHandler", 2];
-
-			[_entity, "turnedOn", true] remoteExecCall ["AE3_interaction_fnc_manageAce3Interactions", 2];
-
-			// we need to set power state here because function already returned false
-			// and therefore the turn on wrapper doesn't set the state to turned on
-			_entity setVariable ["AE3_power_powerState", 1, true];
+			[_entity] call _turnOnFnc;
 		},
 		{
 			// following code only runs on progress bar fail
@@ -53,7 +61,13 @@ if (_fuelLevel > 0) then
 		},
 		(localize "STR_AE3_Power_Interaction_TurnOn" + "...")
 	] call ace_common_fnc_progressBar;
+	}else
+	{
+		[_entity] call _turnOnFnc;
+	};
 };
+
+
 
 // function immediately returns false, because progress bar runs unscheduled
 _result;

--- a/addons/power/functions/fnc_turnOnSolarAction.sqf
+++ b/addons/power/functions/fnc_turnOnSolarAction.sqf
@@ -8,34 +8,44 @@
  * None
  */
 
-params ["_entity"];
+params ["_entity", ["_silent", false]];
 
 private _result = false;
 
 private _turnOnTime = 3;
 
-[
-	_turnOnTime,
-	[_entity], 
-	{
-		// following code only runs on progress bar success
-		params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
-		
-		_args params ["_entity"];
+private _turnOnFnc = {
+	params['_entity'];
 
-		[_entity, AE3_power_fnc_solarCalculation] remoteExecCall ["AE3_power_fnc_addProviderHandler", 2];
+	[_entity, AE3_power_fnc_solarCalculation] remoteExecCall ["AE3_power_fnc_addProviderHandler", 2];
+	[_entity, "turnedOn", true] remoteExecCall ["AE3_interaction_fnc_manageAce3Interactions", 2];
 
-		[_entity, "turnedOn", true] remoteExecCall ["AE3_interaction_fnc_manageAce3Interactions", 2];
+	// we need to set power state here because function already returned false
+	// and therefore the turn on wrapper doesn't set the state to turned on
+	_entity setVariable ["AE3_power_powerState", 1, true];
+};
 
-		// we need to set power state here because function already returned false
-		// and therefore the turn on wrapper doesn't set the state to turned on
-		_entity setVariable ["AE3_power_powerState", 1, true];
-	},
-	{
-		// following code only runs on progress bar fail
-	},
-	(localize "STR_AE3_Power_Interaction_TurnOn" + "...")
-] call ace_common_fnc_progressBar;
+if (!_silent) then {
+	[
+		_turnOnTime,
+		[_entity, _turnOnFnc], 
+		{
+			// following code only runs on progress bar success
+			params ["_args", "_elapsedTime", "_totalTime", "_errorCode"];
+			
+			_args params ["_entity", "_turnOnFnc"];
+
+			[_entity] call _turnOnFnc;
+		},
+		{
+			// following code only runs on progress bar fail
+		},
+		(localize "STR_AE3_Power_Interaction_TurnOn" + "...")
+	] call ace_common_fnc_progressBar;
+}else
+{
+	[_entity] call _turnOnFnc;
+};
 
 // function immediately returns false, because progress bar runs unscheduled
 _result;


### PR DESCRIPTION
Added an eden attribute to power devices to power them on, on mission start.