### PR TITLE
added variable computer brand in terminal

### DIFF
--- a/addons/armaos/functions/fnc_terminal_init.sqf
+++ b/addons/armaos/functions/fnc_terminal_init.sqf
@@ -70,6 +70,20 @@ _terminal = _computer getVariable "AE3_terminal";
 
 private _consoleDialog = createDialog ["AE3_ArmaOS_Main_Dialog", true];
 
+/* ---------------------------------------- */
+
+// computer brand can be changed for every computer individually
+private _headerCtrl = _consoleDialog displayCtrl 1000;
+private _computerBrand = _computer getVariable ["AE3_computerBrand", nil];
+if (isNil "_computerBrand") then
+{
+	_computerBrand = ctrlText _headerCtrl;
+	_computer setVariable ["AE3_computerBrand", _computerBrand, true];
+};
+_headerCtrl ctrlSetText _computerBrand;
+
+/* ---------------------------------------- */
+
 private _consoleOutput = _consoleDialog displayCtrl 1100;
 private _languageButton = _consoleDialog displayCtrl 1310;
 private _designButton = _consoleDialog displayCtrl 1320;


### PR DESCRIPTION
Merging this pull request will allow setting the computer brand in terminal on an per device basis. Simply add this line to the init field of your computer:
```sqf
this setVariable ["AE3_computerBrand", "MY CUSTOM COMPUTER BRAND", true];
```

<img width="969" alt="image" src="https://github.com/y0014984/Advanced-Equipment/assets/50139270/c1108564-6a74-4f9c-b36b-6d98ee69e9a6">
